### PR TITLE
README: Update "License" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,4 +39,7 @@ What happens in particular is:
 
 License
 ------------------------------------------------------------------------------
-ember-hbs-minifier is licensed under the [MIT License](LICENSE.md).
+
+ember-test-selectors is developed by and &copy;
+[simplabs GmbH](http://simplabs.com) and contributors. It is released under the
+[MIT License](LICENSE.md).


### PR DESCRIPTION
This PR introduces the same wording for the "License" section as in e.g. https://github.com/simplabs/ember-test-selectors#license