### PR TITLE
Collapse multiple leading and trailing whitespaces into a single whitespace / Does not collapse multiple &nbsp;

### DIFF
--- a/__snapshots__/hbs-minifier-plugin.test.js.snap
+++ b/__snapshots__/hbs-minifier-plugin.test.js.snap
@@ -1,5 +1,244 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`11. does not collapse multiple &nbsp; textNode into a single whitespace 1`] = `
+Object {
+  "blockParams": Array [],
+  "body": Array [
+    Object {
+      "attributes": Array [],
+      "blockParams": Array [],
+      "children": Array [
+        Object {
+          "chars": "1",
+          "loc": Object {
+            "end": Object {
+              "column": 7,
+              "line": 1,
+            },
+            "source": null,
+            "start": Object {
+              "column": 6,
+              "line": 1,
+            },
+          },
+          "type": "TextNode",
+        },
+      ],
+      "comments": Array [],
+      "loc": Object {
+        "end": Object {
+          "column": 14,
+          "line": 1,
+        },
+        "source": null,
+        "start": Object {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "modifiers": Array [],
+      "tag": "span",
+      "type": "ElementNode",
+    },
+    Object {
+      "chars": "  ",
+      "loc": Object {
+        "end": Object {
+          "column": 26,
+          "line": 1,
+        },
+        "source": null,
+        "start": Object {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "type": "TextNode",
+    },
+    Object {
+      "attributes": Array [],
+      "blockParams": Array [],
+      "children": Array [
+        Object {
+          "chars": "2",
+          "loc": Object {
+            "end": Object {
+              "column": 33,
+              "line": 1,
+            },
+            "source": null,
+            "start": Object {
+              "column": 32,
+              "line": 1,
+            },
+          },
+          "type": "TextNode",
+        },
+      ],
+      "comments": Array [],
+      "loc": Object {
+        "end": Object {
+          "column": 40,
+          "line": 1,
+        },
+        "source": null,
+        "start": Object {
+          "column": 26,
+          "line": 1,
+        },
+      },
+      "modifiers": Array [],
+      "tag": "span",
+      "type": "ElementNode",
+    },
+  ],
+  "loc": Object {
+    "end": Object {
+      "column": 40,
+      "line": 1,
+    },
+    "source": null,
+    "start": Object {
+      "column": 0,
+      "line": 1,
+    },
+  },
+  "type": "Program",
+}
+`;
+
+exports[`11. does not collapse multiple &nbsp; textNode into a single whitespace 2`] = `"<span>1</span>  <span>2</span>"`;
+
+exports[`12. does not collapse &nbsp; surrounding a text content into a single whitespace 1`] = `
+Object {
+  "blockParams": Array [],
+  "body": Array [
+    Object {
+      "attributes": Array [],
+      "blockParams": Array [],
+      "children": Array [
+        Object {
+          "attributes": Array [],
+          "blockParams": Array [],
+          "children": Array [
+            Object {
+              "chars": "  1  ",
+              "loc": Object {
+                "end": Object {
+                  "column": 28,
+                  "line": 2,
+                },
+                "source": null,
+                "start": Object {
+                  "column": 8,
+                  "line": 2,
+                },
+              },
+              "type": "TextNode",
+            },
+          ],
+          "comments": Array [],
+          "loc": Object {
+            "end": Object {
+              "column": 35,
+              "line": 2,
+            },
+            "source": null,
+            "start": Object {
+              "column": 2,
+              "line": 2,
+            },
+          },
+          "modifiers": Array [],
+          "tag": "span",
+          "type": "ElementNode",
+        },
+        Object {
+          "chars": " ",
+          "loc": Object {
+            "end": Object {
+              "column": 2,
+              "line": 3,
+            },
+            "source": null,
+            "start": Object {
+              "column": 35,
+              "line": 2,
+            },
+          },
+          "type": "TextNode",
+        },
+        Object {
+          "attributes": Array [],
+          "blockParams": Array [],
+          "children": Array [
+            Object {
+              "chars": " 2 ",
+              "loc": Object {
+                "end": Object {
+                  "column": 13,
+                  "line": 3,
+                },
+                "source": null,
+                "start": Object {
+                  "column": 8,
+                  "line": 3,
+                },
+              },
+              "type": "TextNode",
+            },
+          ],
+          "comments": Array [],
+          "loc": Object {
+            "end": Object {
+              "column": 20,
+              "line": 3,
+            },
+            "source": null,
+            "start": Object {
+              "column": 2,
+              "line": 3,
+            },
+          },
+          "modifiers": Array [],
+          "tag": "span",
+          "type": "ElementNode",
+        },
+      ],
+      "comments": Array [],
+      "loc": Object {
+        "end": Object {
+          "column": 6,
+          "line": 4,
+        },
+        "source": null,
+        "start": Object {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "modifiers": Array [],
+      "tag": "div",
+      "type": "ElementNode",
+    },
+  ],
+  "loc": Object {
+    "end": Object {
+      "column": 6,
+      "line": 4,
+    },
+    "source": null,
+    "start": Object {
+      "column": 0,
+      "line": 1,
+    },
+  },
+  "type": "Program",
+}
+`;
+
+exports[`12. does not collapse &nbsp; surrounding a text content into a single whitespace 2`] = `"<div><span>  1  </span> <span> 2 </span></div>"`;
+
 exports[`collapses whitespace into single space character 1`] = `
 Object {
   "blockParams": Array [],
@@ -631,7 +870,7 @@ Object {
       "blockParams": Array [],
       "children": Array [
         Object {
-          "chars": "x        ",
+          "chars": "x ",
           "loc": Object {
             "end": Object {
               "column": 14,
@@ -697,7 +936,7 @@ Object {
           "type": "MustacheStatement",
         },
         Object {
-          "chars": "     y   ",
+          "chars": " y ",
           "loc": Object {
             "end": Object {
               "column": 30,
@@ -744,14 +983,14 @@ Object {
 }
 `;
 
-exports[`does not strip leading/trailing text from ElementNode nodes 2`] = `"<div>x        {{foo}}     y   </div>"`;
+exports[`does not strip leading/trailing text from ElementNode nodes 2`] = `"<div>x {{foo}} y </div>"`;
 
 exports[`does not strip leading/trailing text from Program nodes 1`] = `
 Object {
   "blockParams": Array [],
   "body": Array [
     Object {
-      "chars": "x        ",
+      "chars": "x ",
       "loc": Object {
         "end": Object {
           "column": 9,
@@ -817,7 +1056,7 @@ Object {
       "type": "MustacheStatement",
     },
     Object {
-      "chars": "     y   ",
+      "chars": " y ",
       "loc": Object {
         "end": Object {
           "column": 25,
@@ -847,7 +1086,7 @@ Object {
 }
 `;
 
-exports[`does not strip leading/trailing text from Program nodes 2`] = `"x        {{foo}}     y   "`;
+exports[`does not strip leading/trailing text from Program nodes 2`] = `"x {{foo}} y "`;
 
 exports[`strips leading and trailing whitespace from ElementNode nodes 1`] = `
 Object {

--- a/hbs-minifier-plugin.js
+++ b/hbs-minifier-plugin.js
@@ -1,17 +1,21 @@
 'use strict';
 
 /* eslint-env node */
+const Util = require('./utils/helpers');
+const stripWhiteSpace = Util.stripWhiteSpace;
+const isWhitespaceTextNode = Util.isWhitespaceTextNode;
+const hasLeadingOrTrailingWhiteSpace = Util.hasLeadingOrTrailingWhiteSpace;
+const stripNoMinifyBlocks = Util.stripNoMinifyBlocks;
 
-const WHITESPACE = /^\s+$/;
+class HBSMinifierPlugin {
 
-module.exports = class HBSMinifierPlugin {
   static createASTPlugin() {
     let preStack = [];
-
     let visitor = {
       TextNode(node) {
-        if (preStack.length === 0 && WHITESPACE.test(node.chars)) {
-          node.chars = ' ';
+        let chars = node.chars;
+        if (preStack.length === 0 && hasLeadingOrTrailingWhiteSpace(chars)) {
+          node.chars = stripWhiteSpace(chars);
         }
       },
 
@@ -92,17 +96,7 @@ module.exports = class HBSMinifierPlugin {
 
     return ast;
   }
-};
 
-function isWhitespaceTextNode(node) {
-  return node && node.type === 'TextNode' && WHITESPACE.test(node.chars);
 }
 
-function stripNoMinifyBlocks(nodes) {
-  return nodes.map(node => {
-    if (node.type === 'BlockStatement' && node.path.original === 'no-minify') {
-      return node.program.body;
-    }
-    return node;
-  }).reduce((a, b) => a.concat(b), []);
-}
+module.exports = HBSMinifierPlugin;

--- a/hbs-minifier-plugin.test.js
+++ b/hbs-minifier-plugin.test.js
@@ -45,6 +45,17 @@ it('does not collapse whitespace inside of {{#no-minify}} tags in other tags', f
   assert(`<div>{{#no-minify}}  \n\n   \n{{/no-minify}}</div>`);
 });
 
+it('11. does not collapse multiple &nbsp; textNode into a single whitespace', function() {
+  assert(`<span>1</span>&nbsp;&nbsp;<span>2</span>`);
+});
+
+it('12. does not collapse &nbsp; surrounding a text content into a single whitespace', function() {
+  assert(`<div>
+  <span>    &nbsp;1&nbsp;   </span>
+  <span> 2   </span>
+</div>`);
+});
+
 function assert(template) {
   let ast = process(template);
   expect(ast).toMatchSnapshot();

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "author": "",
   "files": [
     "hbs-minifier-plugin.js",
-    "index.js"
+    "index.js",
+    "utils"
   ],
   "directories": {
     "doc": "doc",

--- a/tests/integration/components/dummy-component-test.js
+++ b/tests/integration/components/dummy-component-test.js
@@ -28,17 +28,17 @@ describe('HBS Minifier plugin', function() {
     expect(childNodes[0]).to.have.a.property('textContent', 'foo');
   });
 
-  it('does not strip leading/trailing text from Program nodes', function() {
+  it('Collapse leading/trailing text from Program nodes into a single whitespace', function() {
     this.render(hbs`x        {{foo}}     y   `);
 
     let childNodes = this.$()[0].childNodes;
     expect(childNodes.length).to.equal(3);
     expect(childNodes[0]).to.be.a('text');
-    expect(childNodes[0]).to.have.a.property('textContent', 'x        ');
+    expect(childNodes[0]).to.have.a.property('textContent', 'x ');
     expect(childNodes[1]).to.be.a('text');
     expect(childNodes[1]).to.have.a.property('textContent', 'foo');
     expect(childNodes[2]).to.be.a('text');
-    expect(childNodes[2]).to.have.a.property('textContent', '     y   ');
+    expect(childNodes[2]).to.have.a.property('textContent', ' y ');
   });
 
   it('strips leading and trailing whitespace from ElementNode nodes', function() {
@@ -50,17 +50,19 @@ describe('HBS Minifier plugin', function() {
     expect(childNodes[0]).to.have.a.property('textContent', 'foo');
   });
 
-  it('does not strip leading/trailing text from ElementNode nodes', function() {
-    this.render(hbs`<div>x        {{foo}}     y   </div>`);
+  it('Collapse leading/trailing text from ElementNode nodes', function() {
+    this.render(hbs`<div>x        {{foo}}     y   {{bar}}    z</div>`);
 
     let childNodes = this.$('div')[0].childNodes;
-    expect(childNodes.length).to.equal(3);
+    expect(childNodes.length).to.equal(5);
     expect(childNodes[0]).to.be.a('text');
-    expect(childNodes[0]).to.have.a.property('textContent', 'x        ');
+    expect(childNodes[0]).to.have.a.property('textContent', 'x ');
     expect(childNodes[1]).to.be.a('text');
     expect(childNodes[1]).to.have.a.property('textContent', 'foo');
     expect(childNodes[2]).to.be.a('text');
-    expect(childNodes[2]).to.have.a.property('textContent', '     y   ');
+    expect(childNodes[2]).to.have.a.property('textContent', ' y ');
+    expect(childNodes[3]).to.have.a.property('textContent', 'bar');
+    expect(childNodes[4]).to.have.a.property('textContent', ' z');
   });
 
   it('does not strip inside of <pre> tags', function() {
@@ -119,4 +121,32 @@ describe('HBS Minifier plugin', function() {
     expect(childNodes[0]).to.be.a('text');
     expect(childNodes[0]).to.have.a.property('textContent', '  \n\n   \n');
   });
+
+  it('does not collapse multiple &nbsp; textNode into a single whitespace', function() {
+    this.render(hbs`<span>1</span>&nbsp;&nbsp;<span>2</span>`);
+    let childNodes = this.$()[0].childNodes;
+    expect(childNodes.length).to.equal(3);
+    expect(childNodes[1]).to.be.a('text');
+    // checking for the length of the textNode is 2.
+    expect(childNodes[1].nodeValue.length).to.equal(2);
+    // ensuring the textNode contains only whitespaces
+    expect(childNodes[1].nodeValue.trim()).to.equal('');
+  });
+  /*
+    The following test is so much similar to the above one. But we need to make sure that the textNode in following templates results in
+    '  1  ' and not ' 1 '.
+  */
+  it('does not collapse &nbsp; surrounding a text content into a single whitespace', function() {
+    this.render(hbs `
+<div>
+  <span>    &nbsp;1&nbsp;   </span>
+  <span> 2   </span>
+</div>`);
+    let childNode = this.$('div span:eq(0)')[0].childNodes[0];
+    expect(childNode.textContent.length).to.equal(5);
+    expect(childNode).to.be.a('text');
+    // ensuring the textContent is surrounded by whitespaces
+    expect(childNode.textContent.trim()).to.equal('1');
+  });
+
 });

--- a/utils/helpers.js
+++ b/utils/helpers.js
@@ -1,43 +1,38 @@
 /* eslint-env node */
 'use strict';
 
-// below are the encoded values of ' ', '\n' and '\t' to avoid collapsing multiple &nbsp; into a single whitespace.
-const matchHorizontalTABAndNewLineBegin = /^(%20|%09|%0A)+/;
-const matchHorizontalTABAndNewLineEnd = /(%20|%09|%0A)+$/;
-const WHITESPACE = /^(%20|%09|%0A)+$/;
+const leadingWhiteSpace = /^[ \t\r\n]+/;
+const trailingWhiteSpace = /[ \t\r\n]+$/;
+const WHITESPACE = /^[ \t\r\n]+$/;
 
-const isWhitespaceTextNode = function(node) {
-  return node && node.type === 'TextNode' && WHITESPACE.test(encodeURIComponent(node.chars));
-};
+function isWhitespaceTextNode(node) {
+  return node && node.type === 'TextNode' && WHITESPACE.test(node.chars);
+}
 
-const hasLeadingOrTrailingWhiteSpace = function(chars) {
-  chars = encodeURIComponent(chars);
-  return matchHorizontalTABAndNewLineBegin.test(chars) || matchHorizontalTABAndNewLineEnd.test(chars);
-};
+function hasLeadingOrTrailingWhiteSpace(chars) {
+  return leadingWhiteSpace.test(chars) || trailingWhiteSpace.test(chars);
+}
 
-const stripWhiteSpace = function(chars) {
+function stripWhiteSpace(chars) {
   /*
-    Replacing multiple ' '(leading/trailing), '\n' and '\t' into a single whitespace.
+    Replacing multiple ' ', '\n' and '\t'(leading/trailing) into a single whitespace.
   */
-  chars = encodeURIComponent(chars || '');
-  chars = chars.replace(matchHorizontalTABAndNewLineBegin, ' ')
-   .replace(matchHorizontalTABAndNewLineEnd, ' ');
-  return decodeURIComponent(chars);
-};
+  chars = chars || '';
+  return chars.replace(leadingWhiteSpace, ' ').replace(trailingWhiteSpace, ' ');
+}
 
-const stripNoMinifyBlocks = function(nodes) {
+function stripNoMinifyBlocks(nodes) {
   return nodes.map(node => {
     if (node.type === 'BlockStatement' && node.path.original === 'no-minify') {
       return node.program.body;
     }
     return node;
   }).reduce((a, b) => a.concat(b), []);
-};
+}
 
 module.exports = {
   stripWhiteSpace,
   isWhitespaceTextNode,
-  WHITESPACE,
   stripNoMinifyBlocks,
   hasLeadingOrTrailingWhiteSpace
 };

--- a/utils/helpers.js
+++ b/utils/helpers.js
@@ -1,0 +1,43 @@
+/* eslint-env node */
+'use strict';
+
+// below are the encoded values of ' ', '\n' and '\t' to avoid collapsing multiple &nbsp; into a single whitespace.
+const matchHorizontalTABAndNewLineBegin = /^(%20|%09|%0A)+/;
+const matchHorizontalTABAndNewLineEnd = /(%20|%09|%0A)+$/;
+const WHITESPACE = /^(%20|%09|%0A)+$/;
+
+const isWhitespaceTextNode = function(node) {
+  return node && node.type === 'TextNode' && WHITESPACE.test(encodeURIComponent(node.chars));
+};
+
+const hasLeadingOrTrailingWhiteSpace = function(chars) {
+  chars = encodeURIComponent(chars);
+  return matchHorizontalTABAndNewLineBegin.test(chars) || matchHorizontalTABAndNewLineEnd.test(chars);
+};
+
+const stripWhiteSpace = function(chars) {
+  /*
+    Replacing multiple ' '(leading/trailing), '\n' and '\t' into a single whitespace.
+  */
+  chars = encodeURIComponent(chars || '');
+  chars = chars.replace(matchHorizontalTABAndNewLineBegin, ' ')
+   .replace(matchHorizontalTABAndNewLineEnd, ' ');
+  return decodeURIComponent(chars);
+};
+
+const stripNoMinifyBlocks = function(nodes) {
+  return nodes.map(node => {
+    if (node.type === 'BlockStatement' && node.path.original === 'no-minify') {
+      return node.program.body;
+    }
+    return node;
+  }).reduce((a, b) => a.concat(b), []);
+};
+
+module.exports = {
+  stripWhiteSpace,
+  isWhitespaceTextNode,
+  WHITESPACE,
+  stripNoMinifyBlocks,
+  hasLeadingOrTrailingWhiteSpace
+};


### PR DESCRIPTION
This PR collapses multiple leading and trailing whitespaces into a single whitespace as mentioned below.

Actual content:
```hbs

<div>
    <span>    a     </span>    
    <span>    b    c     </span>
</div>
```


Minified content:

```hbs

<div><span> a </span> <span> b c </span></div>
```