### PR TITLE
Move ember-cli-babel to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,14 +24,12 @@
     "test:ember": "ember test",
     "lint": "eslint app addon blueprints config server test-support tests *.js"
   },
-  "dependencies": {
-    "ember-cli-babel": "^5.1.7"
-  },
   "devDependencies": {
     "@glimmer/syntax": "^0.29.1",
     "broccoli-asset-rev": "^2.4.5",
     "ember-ajax": "^2.4.1",
     "ember-cli": "~2.11.0",
+    "ember-cli-babel": "^5.1.7",
     "ember-cli-chai": "0.3.2",
     "ember-cli-dependency-checker": "^1.3.0",
     "ember-cli-eslint": "^3.0.2",


### PR DESCRIPTION
Not needed as no `addon` or `app` dir is present for the consumers of this addon.