### PR TITLE
ember-try: Disable `beta` and `canary` scenarios

### DIFF
--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -2,4 +2,5 @@
 module.exports = {
   command: 'yarn run ember test',
   useVersionCompatibility: true,
+  scenarios: [],
 };


### PR DESCRIPTION
These do not work anymore with PhantomJS. Once we use headless Chrome everywhere we can enable them again.