### PR TITLE
chore: update CI node version to 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   # we recommend testing addons with the same minimum supported node version as Ember CLI
   # so that your addon works for all apps
-  - "4"
+  - 6
 
 sudo: false
 dist: trusty


### PR DESCRIPTION
This library depends on execa@1.0.0, which requires node 6 or above