### PR TITLE
Drop support for Node 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "object-hash": "1.2.0"
   },
   "engines": {
-    "node": ">= 4"
+    "node": "6.* || 8.* || >= 10.*"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",


### PR DESCRIPTION
because Node 4 is EOL