### PR TITLE
Drop support for Node 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 ---
 language: node_js
-node_js:
-  # we recommend testing addons with the same minimum supported node version as Ember CLI
-  # so that your addon works for all apps
-  - 6
+node_js: "8"
 
 branches:
   only:

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "object-hash": "1.3.1"
   },
   "engines": {
-    "node": "6.* || 8.* || >= 10.*"
+    "node": "8.* || >= 10.*"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",


### PR DESCRIPTION
Node 6 will reach it's official end-of-life in three days so it seems fine to finally drop support for it.