### PR TITLE
Drop support for Ember.js below v3.4.0

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,4 +1,0 @@
-{
-  "directory": "bower_components",
-  "analytics": false
-}

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,12 +19,9 @@ cache:
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash
   - export PATH=$HOME/.yarn/bin:$PATH
-  - yarn global add bower
-  - bower --version
 
 install:
   - yarn install --no-lockfile
-  - bower install
 
 script:
   - yarn test

--- a/bower.json
+++ b/bower.json
@@ -1,4 +1,0 @@
-{
-  "name": "ember-hbs-minifier",
-  "dependencies": {}
-}

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   "ember-addon": {
     "configPath": "tests/dummy/config",
     "versionCompatibility": {
-      "ember": ">=2.0.0"
+      "ember": ">=3.4.0"
     }
   }
 }


### PR DESCRIPTION
This is not strictly necessary since the addon probably still works fine, but to keep our CI times reasonable we will officially drop support for versions that are not even supported by the Ember team itself anymore.