### PR TITLE
Remove jQuery usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "lint": "eslint app addon blueprints config server test-support tests *.js"
   },
   "devDependencies": {
+    "@ember/optional-features": "^0.7.0",
     "@glimmer/syntax": "^0.33.0",
     "broccoli-asset-rev": "^2.4.5",
     "ember-cli": "~3.9.0",

--- a/tests/dummy/config/optional-features.json
+++ b/tests/dummy/config/optional-features.json
@@ -1,0 +1,3 @@
+{
+  "jquery-integration": false
+}

--- a/tests/minifier-test.js
+++ b/tests/minifier-test.js
@@ -14,7 +14,7 @@ describe('HBS Minifier plugin', function() {
   it('collapses whitespace into single space character', async function() {
     await render(hbs`{{foo}}  \n\n   \n{{bar}}`);
 
-    let childNodes = [...this.$()[0].childNodes].filter(it => it.textContent !== '');
+    let childNodes = [...this.element.childNodes].filter(it => it.textContent !== '');
     expect(childNodes.length).to.equal(3);
     expect(childNodes[1]).to.be.a('text');
     expect(childNodes[1]).to.have.a.property('textContent', ' ');
@@ -23,7 +23,7 @@ describe('HBS Minifier plugin', function() {
   it('strips leading and trailing whitespace from Program nodes', async function() {
     await render(hbs`        {{foo}}        `);
 
-    let childNodes = [...this.$()[0].childNodes].filter(it => it.textContent !== '');
+    let childNodes = [...this.element.childNodes].filter(it => it.textContent !== '');
     expect(childNodes.length).to.equal(1);
     expect(childNodes[0]).to.be.a('text');
     expect(childNodes[0]).to.have.a.property('textContent', 'foo');
@@ -32,7 +32,7 @@ describe('HBS Minifier plugin', function() {
   it('Collapse leading/trailing text from Program nodes into a single whitespace', async function() {
     await render(hbs`x        {{foo}}     y   `);
 
-    let childNodes = [...this.$()[0].childNodes].filter(it => it.textContent !== '');
+    let childNodes = [...this.element.childNodes].filter(it => it.textContent !== '');
     expect(childNodes.length).to.equal(3);
     expect(childNodes[0]).to.be.a('text');
     expect(childNodes[0]).to.have.a.property('textContent', 'x ');
@@ -45,7 +45,7 @@ describe('HBS Minifier plugin', function() {
   it('strips leading and trailing whitespace from ElementNode nodes', async function() {
     await render(hbs`<div>        {{foo}}        </div>`);
 
-    let childNodes = this.$('div')[0].childNodes;
+    let childNodes = this.element.querySelector('div').childNodes;
     expect(childNodes.length).to.equal(1);
     expect(childNodes[0]).to.be.a('text');
     expect(childNodes[0]).to.have.a.property('textContent', 'foo');
@@ -54,7 +54,7 @@ describe('HBS Minifier plugin', function() {
   it('Collapse leading/trailing text from ElementNode nodes', async function() {
     await render(hbs`<div>x        {{foo}}     y   {{bar}}    z</div>`);
 
-    let childNodes = this.$('div')[0].childNodes;
+    let childNodes = this.element.querySelector('div').childNodes;
     expect(childNodes.length).to.equal(5);
     expect(childNodes[0]).to.be.a('text');
     expect(childNodes[0]).to.have.a.property('textContent', 'x ');
@@ -69,7 +69,7 @@ describe('HBS Minifier plugin', function() {
   it('does not strip inside of <pre> tags', async function() {
     await render(hbs`<pre>        {{foo}}        </pre>`);
 
-    let childNodes = this.$('pre')[0].childNodes;
+    let childNodes = this.element.querySelector('pre').childNodes;
     expect(childNodes.length).to.equal(3);
     expect(childNodes[0]).to.be.a('text');
     expect(childNodes[0]).to.have.a.property('textContent', '        ');
@@ -82,7 +82,7 @@ describe('HBS Minifier plugin', function() {
   it('does not collapse whitespace inside of <pre> tags', async function() {
     await render(hbs`<pre>  \n\n   \n</pre>`);
 
-    let childNodes = this.$('pre')[0].childNodes;
+    let childNodes = this.element.querySelector('pre').childNodes;
     expect(childNodes.length).to.equal(1);
     expect(childNodes[0]).to.be.a('text');
     expect(childNodes[0]).to.have.a.property('textContent', '  \n\n   \n');
@@ -91,7 +91,7 @@ describe('HBS Minifier plugin', function() {
   it('does not strip inside of {{#no-minify}} tags', async function() {
     await render(hbs`{{#no-minify}}        {{foo}}        {{/no-minify}}`);
 
-    let childNodes = [...this.$()[0].childNodes].filter(it => it.textContent !== '');
+    let childNodes = [...this.element.childNodes].filter(it => it.textContent !== '');
     expect(childNodes.length).to.equal(3);
     expect(childNodes[0]).to.be.a('text');
     expect(childNodes[0]).to.have.a.property('textContent', '        ');
@@ -104,7 +104,7 @@ describe('HBS Minifier plugin', function() {
   it('does not strip inside of {{#no-minify}} tags in other tags', async function() {
     await render(hbs`<div>{{#no-minify}}        {{foo}}        {{/no-minify}}</div>`);
 
-    let childNodes = this.$('div')[0].childNodes;
+    let childNodes = this.element.querySelector('div').childNodes;
     expect(childNodes.length).to.equal(3);
     expect(childNodes[0]).to.be.a('text');
     expect(childNodes[0]).to.have.a.property('textContent', '        ');
@@ -117,7 +117,7 @@ describe('HBS Minifier plugin', function() {
   it('does not collapse whitespace inside of {{#no-minify}} tags in other tags', async function() {
     await render(hbs`<div>{{#no-minify}}  \n\n   \n{{/no-minify}}</div>`);
 
-    let childNodes = this.$('div')[0].childNodes;
+    let childNodes = this.element.querySelector('div').childNodes;
     expect(childNodes.length).to.equal(1);
     expect(childNodes[0]).to.be.a('text');
     expect(childNodes[0]).to.have.a.property('textContent', '  \n\n   \n');
@@ -125,7 +125,7 @@ describe('HBS Minifier plugin', function() {
 
   it('does not collapse multiple &nbsp; textNode into a single whitespace', async function() {
     await render(hbs`<span>1</span>&nbsp;&nbsp;<span>2</span>`);
-    let childNodes = [...this.$()[0].childNodes].filter(it => it.textContent !== '');
+    let childNodes = [...this.element.childNodes].filter(it => it.textContent !== '');
     expect(childNodes.length).to.equal(3);
     expect(childNodes[1]).to.be.a('text');
     // checking for the length of the textNode is 2.
@@ -143,7 +143,7 @@ describe('HBS Minifier plugin', function() {
   <span>    &nbsp;1&nbsp;   </span>
   <span> 2   </span>
 </div>`);
-    let childNode = this.$('div span:eq(0)')[0].childNodes[0];
+    let childNode = this.element.querySelectorAll('div span')[0].childNodes[0];
     expect(childNode.textContent.length).to.equal(5);
     expect(childNode).to.be.a('text');
     // ensuring the textContent is surrounded by whitespaces
@@ -161,7 +161,7 @@ describe('HBS Minifier plugin', function() {
   <u> USA </u>
 </address>`);
 
-    let childNodes = this.$('address')[0].childNodes;
+    let childNodes = this.element.querySelector('address').childNodes;
     expect(childNodes[0].textContent).to.equal('\n  Box 564,\n  ');
     // ensuring the textContent is surrounded by whitespaces
     expect(childNodes[1].textContent).to.equal('\n    Disneyland\n  ');
@@ -180,7 +180,7 @@ describe('HBS Minifier plugin', function() {
   </span>
 </div>`);
 
-    let childNodes = this.$('div')[0].childNodes;
+    let childNodes = this.element.querySelector('div').childNodes;
     expect(childNodes[0].textContent).to.equal('\n  1\n  ');
     expect(childNodes[1].textContent).to.equal('\n    2\n  ');
     expect(childNodes[2].textContent).to.equal('\n');
@@ -194,7 +194,7 @@ describe('HBS Minifier plugin', function() {
   </span>
 {{/foo-bar}}`);
 
-    let childNodes = this.$('div')[0].childNodes;
+    let childNodes = this.element.querySelector('div').childNodes;
     expect(childNodes[0].textContent).to.equal('1 ');
     expect(childNodes[1].textContent).to.equal(' 2 ');
     expect(childNodes[3].textContent).to.equal(' 3 ');
@@ -215,7 +215,7 @@ describe('HBS Minifier plugin', function() {
     </li>
   </ul>`);
 
-    let childNodes = this.$('ul')[0].childNodes;
+    let childNodes = this.element.querySelector('ul').childNodes;
     expect(childNodes.length).to.equal(3);
     expect(childNodes[0].textContent).to.equal(' 1 ');
     expect(childNodes[1].textContent).to.equal(' ');
@@ -231,7 +231,7 @@ describe('HBS Minifier plugin', function() {
   </span>
 </div>`);
 
-    let childNodes = this.$('div')[0].childNodes;
+    let childNodes = this.element.querySelector('div').childNodes;
     expect(childNodes.length).to.equal(2);
     expect(childNodes[0].textContent).to.equal(' 1 ');
     expect(childNodes[1].textContent).to.equal(' 2 ');
@@ -245,12 +245,12 @@ describe('HBS Minifier plugin', function() {
   </div>
 {{/x-button}}`);
 
-    let childNodes = this.$('button')[0].childNodes;
+    let childNodes = this.element.querySelector('button').childNodes;
     // removing the textNodes with content as '' since htmlbars adds text node boundaries (at the begining and the end) of a template file.
     expect([...childNodes].filter(node => node.textContent !== '').length).to.equal(2);
     expect(childNodes[0].textContent).to.equal('save ');
     expect(childNodes[1].nodeName).to.equal('DIV');
-    let yieldElementChildNodes = this.$('div')[0].childNodes;
+    let yieldElementChildNodes = this.element.querySelector('div').childNodes;
     expect(yieldElementChildNodes.length).to.equal(1);
     expect(yieldElementChildNodes[0].textContent).to.equal(' yield content ');
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -694,6 +694,20 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
+"@ember/optional-features@^0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@ember/optional-features/-/optional-features-0.7.0.tgz#f65a858007020ddfb8342f586112750c32abd2d9"
+  integrity sha512-qLXvL/Kq/COb43oQmCrKx7Fy8k1XJDI2RlgbCnZHH26AGVgJT/sZugx1A2AIxKdamtl/Mi+rQSjGIuscSjqjDw==
+  dependencies:
+    chalk "^2.3.0"
+    co "^4.6.0"
+    ember-cli-version-checker "^2.1.0"
+    glob "^7.1.2"
+    inquirer "^3.3.0"
+    mkdirp "^0.5.1"
+    silent-error "^1.1.0"
+    util.promisify "^1.0.0"
+
 "@ember/test-helpers@^0.7.18":
   version "0.7.27"
   resolved "https://registry.yarnpkg.com/@ember/test-helpers/-/test-helpers-0.7.27.tgz#c622cabd0cbb95b34efc1e1b6274ab5a14edc138"
@@ -2138,7 +2152,7 @@ broccoli-funnel-reducer@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/broccoli-funnel-reducer/-/broccoli-funnel-reducer-1.0.0.tgz#11365b2a785aec9b17972a36df87eef24c5cc0ea"
 
-broccoli-funnel@^1.0.9:
+broccoli-funnel@^1.0.1, broccoli-funnel@^1.0.9:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz#cddc3afc5ff1685a8023488fff74ce6fb5a51296"
   dependencies:
@@ -2200,6 +2214,20 @@ broccoli-lint-eslint@^4.2.1:
     json-stable-stringify "^1.0.1"
     lodash.defaultsdeep "^4.6.0"
     md5-hex "^2.0.0"
+
+broccoli-merge-trees@^1.0.0:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/broccoli-merge-trees/-/broccoli-merge-trees-1.2.4.tgz#a001519bb5067f06589d91afa2942445a2d0fdb5"
+  integrity sha1-oAFRm7UGfwZYnZGvopQkRaLQ/bU=
+  dependencies:
+    broccoli-plugin "^1.3.0"
+    can-symlink "^1.0.0"
+    fast-ordered-set "^1.0.2"
+    fs-tree-diff "^0.5.4"
+    heimdalljs "^0.2.1"
+    heimdalljs-logger "^0.1.7"
+    rimraf "^2.4.3"
+    symlink-or-copy "^1.0.0"
 
 broccoli-merge-trees@^2.0.0:
   version "2.0.0"
@@ -4102,7 +4130,7 @@ fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
 
-fast-ordered-set@^1.0.0:
+fast-ordered-set@^1.0.0, fast-ordered-set@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/fast-ordered-set/-/fast-ordered-set-1.0.3.tgz#3fbb36634f7be79e4f7edbdb4a357dee25d184eb"
   dependencies:
@@ -4950,7 +4978,7 @@ inline-source-map-comment@^1.0.5:
     sum-up "^1.0.1"
     xtend "^4.0.0"
 
-inquirer@^3.0.6:
+inquirer@^3.0.6, inquirer@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-3.3.0.tgz#9dd2f2ad765dcab1ff0443b491442a20ba227dc9"
   dependencies:


### PR DESCRIPTION
jQuery was only used in the tests but to make sure we don't use it in the addon itself we will disable it completely now. this also gets rid of some annoying deprecation warnings at buildtime.