### PR TITLE
CI: Skip unnecessary steps for `npm publish` job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,9 @@ jobs:
     - stage: "Publish"
       name: "npm"
       if: tag IS present
+      before_install: skip
+      install: skip
+      script: skip
       deploy:
         provider: npm
         email: info@simplabs.com


### PR DESCRIPTION
whoops... looks like this didn't work for the v0.4.0 release 😅 