### PR TITLE
Adjust Ember.js support matrix to `~3.4.0 || ~3.8.0 || ~3.12.0 || >= 3.16.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   "ember-addon": {
     "configPath": "tests/dummy/config",
     "versionCompatibility": {
-      "ember": ">=3.4.0"
+      "ember": "~3.4.0 || ~3.8.0 || ~3.12.0 || >= 3.16.0"
     }
   },
   "changelog": {


### PR DESCRIPTION
This PR updates our support matrix to the latest 4 LTS releases plus everything above v3.16. This helps to avoid https://github.com/emberjs/ember.js/pull/18831, by no longer running CI for the v3.13-v3.15 releases.