### PR TITLE
CI: Remove schedule trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,6 @@ on:
       - master
       - 'v*'
   pull_request: {}
-  schedule:
-    - cron:  '0 3 * * *' # daily, at 3am
 
 jobs:
   lint:


### PR DESCRIPTION
Workflows with such triggers are automatically disabled after a while these days due to cryptocurrency idiots...