### PR TITLE
renovate: Disable for `@glimmer/syntax-*` dependencies

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -6,8 +6,13 @@
     ":automergeTesters",
     ":pinOnlyDevDependencies",
   ],
-  
+
   "npm": {
     "postUpdateOptions": ["yarnDedupeFewer"],
   },
+
+  packageRules: [{
+    matchPackagePrefixes: ["@glimmer/syntax-"],
+    enabled: false,
+  }],
 }


### PR DESCRIPTION
We want to keep them fixed to their specified versions and not update them.