### PR TITLE
Replace Mocha with QUnit

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "devDependencies": {
     "@ember/optional-features": "2.0.0",
+    "@ember/test-helpers": "^2.6.0",
     "@glimmer/syntax": "0.62.5",
     "@glimmer/syntax-0.35.11": "npm:@glimmer/syntax@0.35.11",
     "@glimmer/syntax-0.37.1": "npm:@glimmer/syntax@0.37.1",
@@ -45,7 +46,7 @@
     "ember-disable-prototype-extensions": "1.1.3",
     "ember-load-initializers": "2.1.2",
     "ember-maybe-import-regenerator": "1.0.0",
-    "ember-mocha": "0.16.2",
+    "ember-qunit": "^5.1.5",
     "ember-resolver": "8.0.3",
     "ember-source": "3.28.8",
     "ember-try": "2.0.0",
@@ -53,7 +54,8 @@
     "eslint-config-simplabs": "0.4.0",
     "jest": "27.5.1",
     "lerna-changelog": "1.0.1",
-    "loader.js": "4.7.0"
+    "loader.js": "4.7.0",
+    "qunit": "^2.17.2"
   },
   "engines": {
     "node": "10.* || >= 12.*"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,6 +2,7 @@ lockfileVersion: 5.3
 
 specifiers:
   '@ember/optional-features': 2.0.0
+  '@ember/test-helpers': ^2.6.0
   '@glimmer/syntax': 0.62.5
   '@glimmer/syntax-0.35.11': npm:@glimmer/syntax@0.35.11
   '@glimmer/syntax-0.37.1': npm:@glimmer/syntax@0.37.1
@@ -16,7 +17,7 @@ specifiers:
   ember-disable-prototype-extensions: 1.1.3
   ember-load-initializers: 2.1.2
   ember-maybe-import-regenerator: 1.0.0
-  ember-mocha: 0.16.2
+  ember-qunit: ^5.1.5
   ember-resolver: 8.0.3
   ember-source: 3.28.8
   ember-try: 2.0.0
@@ -26,12 +27,14 @@ specifiers:
   jest: 27.5.1
   lerna-changelog: 1.0.1
   loader.js: 4.7.0
+  qunit: ^2.17.2
 
 dependencies:
   hash-obj: 3.0.0
 
 devDependencies:
   '@ember/optional-features': 2.0.0
+  '@ember/test-helpers': 2.6.0
   '@glimmer/syntax': 0.62.5
   '@glimmer/syntax-0.35.11': /@glimmer/syntax/0.35.11
   '@glimmer/syntax-0.37.1': /@glimmer/syntax/0.37.1
@@ -46,7 +49,7 @@ devDependencies:
   ember-disable-prototype-extensions: 1.1.3
   ember-load-initializers: 2.1.2
   ember-maybe-import-regenerator: 1.0.0
-  ember-mocha: 0.16.2
+  ember-qunit: 5.1.5_71cf3139f132abb8fb8e124dd974b045
   ember-resolver: 8.0.3
   ember-source: 3.28.8
   ember-try: 2.0.0
@@ -55,6 +58,7 @@ devDependencies:
   jest: 27.5.1
   lerna-changelog: 1.0.1
   loader.js: 4.7.0
+  qunit: 2.17.2
 
 packages:
 
@@ -241,6 +245,24 @@ packages:
       - supports-color
     dev: true
 
+  /@babel/helper-create-class-features-plugin/7.17.1_@babel+core@7.17.2:
+    resolution: {integrity: sha512-JBdSr/LtyYIno/pNnJ75lBcqc3Z1XXujzPanHqjvvrhOA+DTceTFuJi8XjmWTZh4r3fsdfqaCMN0iZemdkxZHQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.17.2
+      '@babel/helper-annotate-as-pure': 7.16.7
+      '@babel/helper-environment-visitor': 7.16.7
+      '@babel/helper-function-name': 7.16.7
+      '@babel/helper-member-expression-to-functions': 7.16.7
+      '@babel/helper-optimise-call-expression': 7.16.7
+      '@babel/helper-replace-supers': 7.16.7
+      '@babel/helper-split-export-declaration': 7.16.7
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@babel/helper-create-regexp-features-plugin/7.17.0_@babel+core@7.14.3:
     resolution: {integrity: sha512-awO2So99wG6KnlE+TPs6rn83gCz5WlEePJDTnLEqbchMVrBeAujURVphRdigsk094VhvZehFoNOihSlcBjwsXA==}
     engines: {node: '>=6.9.0'}
@@ -248,6 +270,17 @@ packages:
       '@babel/core': ^7.0.0
     dependencies:
       '@babel/core': 7.14.3
+      '@babel/helper-annotate-as-pure': 7.16.7
+      regexpu-core: 5.0.1
+    dev: true
+
+  /@babel/helper-create-regexp-features-plugin/7.17.0_@babel+core@7.17.2:
+    resolution: {integrity: sha512-awO2So99wG6KnlE+TPs6rn83gCz5WlEePJDTnLEqbchMVrBeAujURVphRdigsk094VhvZehFoNOihSlcBjwsXA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.17.2
       '@babel/helper-annotate-as-pure': 7.16.7
       regexpu-core: 5.0.1
     dev: true
@@ -277,6 +310,24 @@ packages:
     dependencies:
       '@babel/core': 7.14.3
       '@babel/helper-compilation-targets': 7.16.7_@babel+core@7.14.3
+      '@babel/helper-module-imports': 7.16.7
+      '@babel/helper-plugin-utils': 7.16.7
+      '@babel/traverse': 7.17.0
+      debug: 4.3.3
+      lodash.debounce: 4.0.8
+      resolve: 1.20.0
+      semver: 6.3.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@babel/helper-define-polyfill-provider/0.3.1_@babel+core@7.17.2:
+    resolution: {integrity: sha512-J9hGMpJQmtWmj46B3kBHmL38UhJGhYX7eqkcq+2gsstyYt341HmPeWspihX43yVRA0mS+8GGk2Gckc7bY/HCmA==}
+    peerDependencies:
+      '@babel/core': ^7.4.0-0
+    dependencies:
+      '@babel/core': 7.17.2
+      '@babel/helper-compilation-targets': 7.16.7_@babel+core@7.17.2
       '@babel/helper-module-imports': 7.16.7
       '@babel/helper-plugin-utils': 7.16.7
       '@babel/traverse': 7.17.0
@@ -482,6 +533,16 @@ packages:
       '@babel/helper-plugin-utils': 7.16.7
     dev: true
 
+  /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/7.16.7_@babel+core@7.17.2:
+    resolution: {integrity: sha512-anv/DObl7waiGEnC24O9zqL0pSuI9hljihqiDuFHC8d7/bjr/4RLGPWuc8rYOff/QPzbEPSkzG8wGG9aDuhHRg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.17.2
+      '@babel/helper-plugin-utils': 7.16.7
+    dev: true
+
   /@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/7.16.7_@babel+core@7.14.3:
     resolution: {integrity: sha512-di8vUHRdf+4aJ7ltXhaDbPoszdkh59AQtJM5soLsuHpQJdFQZOA4uGj0V2u/CZ8bJ/u8ULDL5yq6FO/bCXnKHw==}
     engines: {node: '>=6.9.0'}
@@ -494,6 +555,18 @@ packages:
       '@babel/plugin-proposal-optional-chaining': 7.16.7_@babel+core@7.14.3
     dev: true
 
+  /@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/7.16.7_@babel+core@7.17.2:
+    resolution: {integrity: sha512-di8vUHRdf+4aJ7ltXhaDbPoszdkh59AQtJM5soLsuHpQJdFQZOA4uGj0V2u/CZ8bJ/u8ULDL5yq6FO/bCXnKHw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.13.0
+    dependencies:
+      '@babel/core': 7.17.2
+      '@babel/helper-plugin-utils': 7.16.7
+      '@babel/helper-skip-transparent-expression-wrappers': 7.16.0
+      '@babel/plugin-proposal-optional-chaining': 7.16.7_@babel+core@7.17.2
+    dev: true
+
   /@babel/plugin-proposal-async-generator-functions/7.16.8_@babel+core@7.14.3:
     resolution: {integrity: sha512-71YHIvMuiuqWJQkebWJtdhQTfd4Q4mF76q2IX37uZPkG9+olBxsX+rH1vkhFto4UeJZ9dPY2s+mDvhDm1u2BGQ==}
     engines: {node: '>=6.9.0'}
@@ -504,6 +577,20 @@ packages:
       '@babel/helper-plugin-utils': 7.16.7
       '@babel/helper-remap-async-to-generator': 7.16.8
       '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.14.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@babel/plugin-proposal-async-generator-functions/7.16.8_@babel+core@7.17.2:
+    resolution: {integrity: sha512-71YHIvMuiuqWJQkebWJtdhQTfd4Q4mF76q2IX37uZPkG9+olBxsX+rH1vkhFto4UeJZ9dPY2s+mDvhDm1u2BGQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.17.2
+      '@babel/helper-plugin-utils': 7.16.7
+      '@babel/helper-remap-async-to-generator': 7.16.8
+      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.17.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -533,6 +620,19 @@ packages:
       - supports-color
     dev: true
 
+  /@babel/plugin-proposal-class-properties/7.16.7_@babel+core@7.17.2:
+    resolution: {integrity: sha512-IobU0Xme31ewjYOShSIqd/ZGM/r/cuOz2z0MDbNrhF5FW+ZVgi0f2lyeoj9KFPDOAqsYxmLWZte1WOwlvY9aww==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.17.2
+      '@babel/helper-create-class-features-plugin': 7.17.1_@babel+core@7.17.2
+      '@babel/helper-plugin-utils': 7.16.7
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@babel/plugin-proposal-class-static-block/7.16.7_@babel+core@7.14.3:
     resolution: {integrity: sha512-dgqJJrcZoG/4CkMopzhPJjGxsIe9A8RlkQLnL/Vhhx8AA9ZuaRwGSlscSh42hazc7WSrya/IK7mTeoF0DP9tEw==}
     engines: {node: '>=6.9.0'}
@@ -543,6 +643,20 @@ packages:
       '@babel/helper-create-class-features-plugin': 7.17.1_@babel+core@7.14.3
       '@babel/helper-plugin-utils': 7.16.7
       '@babel/plugin-syntax-class-static-block': 7.14.5_@babel+core@7.14.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@babel/plugin-proposal-class-static-block/7.16.7_@babel+core@7.17.2:
+    resolution: {integrity: sha512-dgqJJrcZoG/4CkMopzhPJjGxsIe9A8RlkQLnL/Vhhx8AA9ZuaRwGSlscSh42hazc7WSrya/IK7mTeoF0DP9tEw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.12.0
+    dependencies:
+      '@babel/core': 7.17.2
+      '@babel/helper-create-class-features-plugin': 7.17.1_@babel+core@7.17.2
+      '@babel/helper-plugin-utils': 7.16.7
+      '@babel/plugin-syntax-class-static-block': 7.14.5_@babel+core@7.17.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -571,6 +685,17 @@ packages:
       '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.14.3
     dev: true
 
+  /@babel/plugin-proposal-dynamic-import/7.16.7_@babel+core@7.17.2:
+    resolution: {integrity: sha512-I8SW9Ho3/8DRSdmDdH3gORdyUuYnk1m4cMxUAdu5oy4n3OfN8flDEH+d60iG7dUfi0KkYwSvoalHzzdRzpWHTg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.17.2
+      '@babel/helper-plugin-utils': 7.16.7
+      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.17.2
+    dev: true
+
   /@babel/plugin-proposal-export-namespace-from/7.16.7_@babel+core@7.14.3:
     resolution: {integrity: sha512-ZxdtqDXLRGBL64ocZcs7ovt71L3jhC1RGSyR996svrCi3PYqHNkb3SwPJCs8RIzD86s+WPpt2S73+EHCGO+NUA==}
     engines: {node: '>=6.9.0'}
@@ -580,6 +705,17 @@ packages:
       '@babel/core': 7.14.3
       '@babel/helper-plugin-utils': 7.16.7
       '@babel/plugin-syntax-export-namespace-from': 7.8.3_@babel+core@7.14.3
+    dev: true
+
+  /@babel/plugin-proposal-export-namespace-from/7.16.7_@babel+core@7.17.2:
+    resolution: {integrity: sha512-ZxdtqDXLRGBL64ocZcs7ovt71L3jhC1RGSyR996svrCi3PYqHNkb3SwPJCs8RIzD86s+WPpt2S73+EHCGO+NUA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.17.2
+      '@babel/helper-plugin-utils': 7.16.7
+      '@babel/plugin-syntax-export-namespace-from': 7.8.3_@babel+core@7.17.2
     dev: true
 
   /@babel/plugin-proposal-json-strings/7.16.7_@babel+core@7.14.3:
@@ -593,6 +729,17 @@ packages:
       '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.14.3
     dev: true
 
+  /@babel/plugin-proposal-json-strings/7.16.7_@babel+core@7.17.2:
+    resolution: {integrity: sha512-lNZ3EEggsGY78JavgbHsK9u5P3pQaW7k4axlgFLYkMd7UBsiNahCITShLjNQschPyjtO6dADrL24757IdhBrsQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.17.2
+      '@babel/helper-plugin-utils': 7.16.7
+      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.17.2
+    dev: true
+
   /@babel/plugin-proposal-logical-assignment-operators/7.16.7_@babel+core@7.14.3:
     resolution: {integrity: sha512-K3XzyZJGQCr00+EtYtrDjmwX7o7PLK6U9bi1nCwkQioRFVUv6dJoxbQjtWVtP+bCPy82bONBKG8NPyQ4+i6yjg==}
     engines: {node: '>=6.9.0'}
@@ -602,6 +749,17 @@ packages:
       '@babel/core': 7.14.3
       '@babel/helper-plugin-utils': 7.16.7
       '@babel/plugin-syntax-logical-assignment-operators': 7.10.4_@babel+core@7.14.3
+    dev: true
+
+  /@babel/plugin-proposal-logical-assignment-operators/7.16.7_@babel+core@7.17.2:
+    resolution: {integrity: sha512-K3XzyZJGQCr00+EtYtrDjmwX7o7PLK6U9bi1nCwkQioRFVUv6dJoxbQjtWVtP+bCPy82bONBKG8NPyQ4+i6yjg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.17.2
+      '@babel/helper-plugin-utils': 7.16.7
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4_@babel+core@7.17.2
     dev: true
 
   /@babel/plugin-proposal-nullish-coalescing-operator/7.16.7_@babel+core@7.14.3:
@@ -615,6 +773,17 @@ packages:
       '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.14.3
     dev: true
 
+  /@babel/plugin-proposal-nullish-coalescing-operator/7.16.7_@babel+core@7.17.2:
+    resolution: {integrity: sha512-aUOrYU3EVtjf62jQrCj63pYZ7k6vns2h/DQvHPWGmsJRYzWXZ6/AsfgpiRy6XiuIDADhJzP2Q9MwSMKauBQ+UQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.17.2
+      '@babel/helper-plugin-utils': 7.16.7
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.17.2
+    dev: true
+
   /@babel/plugin-proposal-numeric-separator/7.16.7_@babel+core@7.14.3:
     resolution: {integrity: sha512-vQgPMknOIgiuVqbokToyXbkY/OmmjAzr/0lhSIbG/KmnzXPGwW/AdhdKpi+O4X/VkWiWjnkKOBiqJrTaC98VKw==}
     engines: {node: '>=6.9.0'}
@@ -624,6 +793,17 @@ packages:
       '@babel/core': 7.14.3
       '@babel/helper-plugin-utils': 7.16.7
       '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.14.3
+    dev: true
+
+  /@babel/plugin-proposal-numeric-separator/7.16.7_@babel+core@7.17.2:
+    resolution: {integrity: sha512-vQgPMknOIgiuVqbokToyXbkY/OmmjAzr/0lhSIbG/KmnzXPGwW/AdhdKpi+O4X/VkWiWjnkKOBiqJrTaC98VKw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.17.2
+      '@babel/helper-plugin-utils': 7.16.7
+      '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.17.2
     dev: true
 
   /@babel/plugin-proposal-object-rest-spread/7.16.7_@babel+core@7.14.3:
@@ -640,6 +820,20 @@ packages:
       '@babel/plugin-transform-parameters': 7.16.7_@babel+core@7.14.3
     dev: true
 
+  /@babel/plugin-proposal-object-rest-spread/7.16.7_@babel+core@7.17.2:
+    resolution: {integrity: sha512-3O0Y4+dw94HA86qSg9IHfyPktgR7q3gpNVAeiKQd+8jBKFaU5NQS1Yatgo4wY+UFNuLjvxcSmzcsHqrhgTyBUA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/compat-data': 7.17.0
+      '@babel/core': 7.17.2
+      '@babel/helper-compilation-targets': 7.16.7_@babel+core@7.17.2
+      '@babel/helper-plugin-utils': 7.16.7
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.17.2
+      '@babel/plugin-transform-parameters': 7.16.7_@babel+core@7.17.2
+    dev: true
+
   /@babel/plugin-proposal-optional-catch-binding/7.16.7_@babel+core@7.14.3:
     resolution: {integrity: sha512-eMOH/L4OvWSZAE1VkHbr1vckLG1WUcHGJSLqqQwl2GaUqG6QjddvrOaTUMNYiv77H5IKPMZ9U9P7EaHwvAShfA==}
     engines: {node: '>=6.9.0'}
@@ -649,6 +843,17 @@ packages:
       '@babel/core': 7.14.3
       '@babel/helper-plugin-utils': 7.16.7
       '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.14.3
+    dev: true
+
+  /@babel/plugin-proposal-optional-catch-binding/7.16.7_@babel+core@7.17.2:
+    resolution: {integrity: sha512-eMOH/L4OvWSZAE1VkHbr1vckLG1WUcHGJSLqqQwl2GaUqG6QjddvrOaTUMNYiv77H5IKPMZ9U9P7EaHwvAShfA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.17.2
+      '@babel/helper-plugin-utils': 7.16.7
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.17.2
     dev: true
 
   /@babel/plugin-proposal-optional-chaining/7.16.7_@babel+core@7.14.3:
@@ -663,6 +868,18 @@ packages:
       '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.14.3
     dev: true
 
+  /@babel/plugin-proposal-optional-chaining/7.16.7_@babel+core@7.17.2:
+    resolution: {integrity: sha512-eC3xy+ZrUcBtP7x+sq62Q/HYd674pPTb/77XZMb5wbDPGWIdUbSr4Agr052+zaUPSb+gGRnjxXfKFvx5iMJ+DA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.17.2
+      '@babel/helper-plugin-utils': 7.16.7
+      '@babel/helper-skip-transparent-expression-wrappers': 7.16.0
+      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.17.2
+    dev: true
+
   /@babel/plugin-proposal-private-methods/7.16.11_@babel+core@7.14.3:
     resolution: {integrity: sha512-F/2uAkPlXDr8+BHpZvo19w3hLFKge+k75XUprE6jaqKxjGkSYcK+4c+bup5PdW/7W/Rpjwql7FTVEDW+fRAQsw==}
     engines: {node: '>=6.9.0'}
@@ -671,6 +888,19 @@ packages:
     dependencies:
       '@babel/core': 7.14.3
       '@babel/helper-create-class-features-plugin': 7.17.1_@babel+core@7.14.3
+      '@babel/helper-plugin-utils': 7.16.7
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@babel/plugin-proposal-private-methods/7.16.11_@babel+core@7.17.2:
+    resolution: {integrity: sha512-F/2uAkPlXDr8+BHpZvo19w3hLFKge+k75XUprE6jaqKxjGkSYcK+4c+bup5PdW/7W/Rpjwql7FTVEDW+fRAQsw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.17.2
+      '@babel/helper-create-class-features-plugin': 7.17.1_@babel+core@7.17.2
       '@babel/helper-plugin-utils': 7.16.7
     transitivePeerDependencies:
       - supports-color
@@ -691,6 +921,21 @@ packages:
       - supports-color
     dev: true
 
+  /@babel/plugin-proposal-private-property-in-object/7.16.7_@babel+core@7.17.2:
+    resolution: {integrity: sha512-rMQkjcOFbm+ufe3bTZLyOfsOUOxyvLXZJCTARhJr+8UMSoZmqTe1K1BgkFcrW37rAchWg57yI69ORxiWvUINuQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.17.2
+      '@babel/helper-annotate-as-pure': 7.16.7
+      '@babel/helper-create-class-features-plugin': 7.17.1_@babel+core@7.17.2
+      '@babel/helper-plugin-utils': 7.16.7
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5_@babel+core@7.17.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@babel/plugin-proposal-unicode-property-regex/7.16.7_@babel+core@7.14.3:
     resolution: {integrity: sha512-QRK0YI/40VLhNVGIjRNAAQkEHws0cswSdFFjpFyt943YmJIU1da9uW63Iu6NFV6CxTZW5eTDCrwZUstBWgp/Rg==}
     engines: {node: '>=4'}
@@ -699,6 +944,17 @@ packages:
     dependencies:
       '@babel/core': 7.14.3
       '@babel/helper-create-regexp-features-plugin': 7.17.0_@babel+core@7.14.3
+      '@babel/helper-plugin-utils': 7.16.7
+    dev: true
+
+  /@babel/plugin-proposal-unicode-property-regex/7.16.7_@babel+core@7.17.2:
+    resolution: {integrity: sha512-QRK0YI/40VLhNVGIjRNAAQkEHws0cswSdFFjpFyt943YmJIU1da9uW63Iu6NFV6CxTZW5eTDCrwZUstBWgp/Rg==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.17.2
+      '@babel/helper-create-regexp-features-plugin': 7.17.0_@babel+core@7.17.2
       '@babel/helper-plugin-utils': 7.16.7
     dev: true
 
@@ -757,6 +1013,16 @@ packages:
       '@babel/helper-plugin-utils': 7.16.7
     dev: true
 
+  /@babel/plugin-syntax-class-static-block/7.14.5_@babel+core@7.17.2:
+    resolution: {integrity: sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.17.2
+      '@babel/helper-plugin-utils': 7.16.7
+    dev: true
+
   /@babel/plugin-syntax-decorators/7.12.13_@babel+core@7.14.3:
     resolution: {integrity: sha512-Rw6aIXGuqDLr6/LoBBYE57nKOzQpz/aDkKlMqEwH+Vp0MXbG6H/TfRjaY343LKxzAKAMXIHsQ8JzaZKuDZ9MwA==}
     peerDependencies:
@@ -775,12 +1041,30 @@ packages:
       '@babel/helper-plugin-utils': 7.16.7
     dev: true
 
+  /@babel/plugin-syntax-dynamic-import/7.8.3_@babel+core@7.17.2:
+    resolution: {integrity: sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.17.2
+      '@babel/helper-plugin-utils': 7.16.7
+    dev: true
+
   /@babel/plugin-syntax-export-namespace-from/7.8.3_@babel+core@7.14.3:
     resolution: {integrity: sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.14.3
+      '@babel/helper-plugin-utils': 7.16.7
+    dev: true
+
+  /@babel/plugin-syntax-export-namespace-from/7.8.3_@babel+core@7.17.2:
+    resolution: {integrity: sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.17.2
       '@babel/helper-plugin-utils': 7.16.7
     dev: true
 
@@ -929,6 +1213,16 @@ packages:
       '@babel/helper-plugin-utils': 7.16.7
     dev: true
 
+  /@babel/plugin-syntax-private-property-in-object/7.14.5_@babel+core@7.17.2:
+    resolution: {integrity: sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.17.2
+      '@babel/helper-plugin-utils': 7.16.7
+    dev: true
+
   /@babel/plugin-syntax-top-level-await/7.14.5_@babel+core@7.14.3:
     resolution: {integrity: sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==}
     engines: {node: '>=6.9.0'}
@@ -985,6 +1279,16 @@ packages:
       '@babel/helper-plugin-utils': 7.16.7
     dev: true
 
+  /@babel/plugin-transform-arrow-functions/7.16.7_@babel+core@7.17.2:
+    resolution: {integrity: sha512-9ffkFFMbvzTvv+7dTp/66xvZAWASuPD5Tl9LK3Z9vhOmANo6j94rik+5YMBt4CwHVMWLWpMsriIc2zsa3WW3xQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.17.2
+      '@babel/helper-plugin-utils': 7.16.7
+    dev: true
+
   /@babel/plugin-transform-async-to-generator/7.16.8_@babel+core@7.14.3:
     resolution: {integrity: sha512-MtmUmTJQHCnyJVrScNzNlofQJ3dLFuobYn3mwOTKHnSCMtbNsqvF71GQmJfFjdrXSsAA7iysFmYWw4bXZ20hOg==}
     engines: {node: '>=6.9.0'}
@@ -999,6 +1303,20 @@ packages:
       - supports-color
     dev: true
 
+  /@babel/plugin-transform-async-to-generator/7.16.8_@babel+core@7.17.2:
+    resolution: {integrity: sha512-MtmUmTJQHCnyJVrScNzNlofQJ3dLFuobYn3mwOTKHnSCMtbNsqvF71GQmJfFjdrXSsAA7iysFmYWw4bXZ20hOg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.17.2
+      '@babel/helper-module-imports': 7.16.7
+      '@babel/helper-plugin-utils': 7.16.7
+      '@babel/helper-remap-async-to-generator': 7.16.8
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@babel/plugin-transform-block-scoped-functions/7.16.7_@babel+core@7.14.3:
     resolution: {integrity: sha512-JUuzlzmF40Z9cXyytcbZEZKckgrQzChbQJw/5PuEHYeqzCsvebDx0K0jWnIIVcmmDOAVctCgnYs0pMcrYj2zJg==}
     engines: {node: '>=6.9.0'}
@@ -1006,6 +1324,16 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.14.3
+      '@babel/helper-plugin-utils': 7.16.7
+    dev: true
+
+  /@babel/plugin-transform-block-scoped-functions/7.16.7_@babel+core@7.17.2:
+    resolution: {integrity: sha512-JUuzlzmF40Z9cXyytcbZEZKckgrQzChbQJw/5PuEHYeqzCsvebDx0K0jWnIIVcmmDOAVctCgnYs0pMcrYj2zJg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.17.2
       '@babel/helper-plugin-utils': 7.16.7
     dev: true
 
@@ -1028,6 +1356,16 @@ packages:
       '@babel/helper-plugin-utils': 7.16.7
     dev: true
 
+  /@babel/plugin-transform-block-scoping/7.16.7_@babel+core@7.17.2:
+    resolution: {integrity: sha512-ObZev2nxVAYA4bhyusELdo9hb3H+A56bxH3FZMbEImZFiEDYVHXQSJ1hQKFlDnlt8G9bBrCZ5ZpURZUrV4G5qQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.17.2
+      '@babel/helper-plugin-utils': 7.16.7
+    dev: true
+
   /@babel/plugin-transform-classes/7.16.7_@babel+core@7.14.3:
     resolution: {integrity: sha512-WY7og38SFAGYRe64BrjKf8OrE6ulEHtr5jEYaZMwox9KebgqPi67Zqz8K53EKk1fFEJgm96r32rkKZ3qA2nCWQ==}
     engines: {node: '>=6.9.0'}
@@ -1035,6 +1373,25 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.14.3
+      '@babel/helper-annotate-as-pure': 7.16.7
+      '@babel/helper-environment-visitor': 7.16.7
+      '@babel/helper-function-name': 7.16.7
+      '@babel/helper-optimise-call-expression': 7.16.7
+      '@babel/helper-plugin-utils': 7.16.7
+      '@babel/helper-replace-supers': 7.16.7
+      '@babel/helper-split-export-declaration': 7.16.7
+      globals: 11.11.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@babel/plugin-transform-classes/7.16.7_@babel+core@7.17.2:
+    resolution: {integrity: sha512-WY7og38SFAGYRe64BrjKf8OrE6ulEHtr5jEYaZMwox9KebgqPi67Zqz8K53EKk1fFEJgm96r32rkKZ3qA2nCWQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.17.2
       '@babel/helper-annotate-as-pure': 7.16.7
       '@babel/helper-environment-visitor': 7.16.7
       '@babel/helper-function-name': 7.16.7
@@ -1057,6 +1414,16 @@ packages:
       '@babel/helper-plugin-utils': 7.16.7
     dev: true
 
+  /@babel/plugin-transform-computed-properties/7.16.7_@babel+core@7.17.2:
+    resolution: {integrity: sha512-gN72G9bcmenVILj//sv1zLNaPyYcOzUho2lIJBMh/iakJ9ygCo/hEF9cpGb61SCMEDxbbyBoVQxrt+bWKu5KGw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.17.2
+      '@babel/helper-plugin-utils': 7.16.7
+    dev: true
+
   /@babel/plugin-transform-destructuring/7.16.7_@babel+core@7.14.3:
     resolution: {integrity: sha512-VqAwhTHBnu5xBVDCvrvqJbtLUa++qZaWC0Fgr2mqokBlulZARGyIvZDoqbPlPaKImQ9dKAcCzbv+ul//uqu70A==}
     engines: {node: '>=6.9.0'}
@@ -1064,6 +1431,16 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.14.3
+      '@babel/helper-plugin-utils': 7.16.7
+    dev: true
+
+  /@babel/plugin-transform-destructuring/7.16.7_@babel+core@7.17.2:
+    resolution: {integrity: sha512-VqAwhTHBnu5xBVDCvrvqJbtLUa++qZaWC0Fgr2mqokBlulZARGyIvZDoqbPlPaKImQ9dKAcCzbv+ul//uqu70A==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.17.2
       '@babel/helper-plugin-utils': 7.16.7
     dev: true
 
@@ -1078,6 +1455,17 @@ packages:
       '@babel/helper-plugin-utils': 7.16.7
     dev: true
 
+  /@babel/plugin-transform-dotall-regex/7.16.7_@babel+core@7.17.2:
+    resolution: {integrity: sha512-Lyttaao2SjZF6Pf4vk1dVKv8YypMpomAbygW+mU5cYP3S5cWTfCJjG8xV6CFdzGFlfWK81IjL9viiTvpb6G7gQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.17.2
+      '@babel/helper-create-regexp-features-plugin': 7.17.0_@babel+core@7.17.2
+      '@babel/helper-plugin-utils': 7.16.7
+    dev: true
+
   /@babel/plugin-transform-duplicate-keys/7.16.7_@babel+core@7.14.3:
     resolution: {integrity: sha512-03DvpbRfvWIXyK0/6QiR1KMTWeT6OcQ7tbhjrXyFS02kjuX/mu5Bvnh5SDSWHxyawit2g5aWhKwI86EE7GUnTw==}
     engines: {node: '>=6.9.0'}
@@ -1085,6 +1473,16 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.14.3
+      '@babel/helper-plugin-utils': 7.16.7
+    dev: true
+
+  /@babel/plugin-transform-duplicate-keys/7.16.7_@babel+core@7.17.2:
+    resolution: {integrity: sha512-03DvpbRfvWIXyK0/6QiR1KMTWeT6OcQ7tbhjrXyFS02kjuX/mu5Bvnh5SDSWHxyawit2g5aWhKwI86EE7GUnTw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.17.2
       '@babel/helper-plugin-utils': 7.16.7
     dev: true
 
@@ -1099,6 +1497,17 @@ packages:
       '@babel/helper-plugin-utils': 7.16.7
     dev: true
 
+  /@babel/plugin-transform-exponentiation-operator/7.16.7_@babel+core@7.17.2:
+    resolution: {integrity: sha512-8UYLSlyLgRixQvlYH3J2ekXFHDFLQutdy7FfFAMm3CPZ6q9wHCwnUyiXpQCe3gVVnQlHc5nsuiEVziteRNTXEA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.17.2
+      '@babel/helper-builder-binary-assignment-operator-visitor': 7.16.7
+      '@babel/helper-plugin-utils': 7.16.7
+    dev: true
+
   /@babel/plugin-transform-for-of/7.16.7_@babel+core@7.14.3:
     resolution: {integrity: sha512-/QZm9W92Ptpw7sjI9Nx1mbcsWz33+l8kuMIQnDwgQBG5s3fAfQvkRjQ7NqXhtNcKOnPkdICmUHyCaWW06HCsqg==}
     engines: {node: '>=6.9.0'}
@@ -1106,6 +1515,16 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.14.3
+      '@babel/helper-plugin-utils': 7.16.7
+    dev: true
+
+  /@babel/plugin-transform-for-of/7.16.7_@babel+core@7.17.2:
+    resolution: {integrity: sha512-/QZm9W92Ptpw7sjI9Nx1mbcsWz33+l8kuMIQnDwgQBG5s3fAfQvkRjQ7NqXhtNcKOnPkdICmUHyCaWW06HCsqg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.17.2
       '@babel/helper-plugin-utils': 7.16.7
     dev: true
 
@@ -1121,6 +1540,18 @@ packages:
       '@babel/helper-plugin-utils': 7.16.7
     dev: true
 
+  /@babel/plugin-transform-function-name/7.16.7_@babel+core@7.17.2:
+    resolution: {integrity: sha512-SU/C68YVwTRxqWj5kgsbKINakGag0KTgq9f2iZEXdStoAbOzLHEBRYzImmA6yFo8YZhJVflvXmIHUO7GWHmxxA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.17.2
+      '@babel/helper-compilation-targets': 7.16.7_@babel+core@7.17.2
+      '@babel/helper-function-name': 7.16.7
+      '@babel/helper-plugin-utils': 7.16.7
+    dev: true
+
   /@babel/plugin-transform-literals/7.16.7_@babel+core@7.14.3:
     resolution: {integrity: sha512-6tH8RTpTWI0s2sV6uq3e/C9wPo4PTqqZps4uF0kzQ9/xPLFQtipynvmT1g/dOfEJ+0EQsHhkQ/zyRId8J2b8zQ==}
     engines: {node: '>=6.9.0'}
@@ -1131,6 +1562,16 @@ packages:
       '@babel/helper-plugin-utils': 7.16.7
     dev: true
 
+  /@babel/plugin-transform-literals/7.16.7_@babel+core@7.17.2:
+    resolution: {integrity: sha512-6tH8RTpTWI0s2sV6uq3e/C9wPo4PTqqZps4uF0kzQ9/xPLFQtipynvmT1g/dOfEJ+0EQsHhkQ/zyRId8J2b8zQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.17.2
+      '@babel/helper-plugin-utils': 7.16.7
+    dev: true
+
   /@babel/plugin-transform-member-expression-literals/7.16.7_@babel+core@7.14.3:
     resolution: {integrity: sha512-mBruRMbktKQwbxaJof32LT9KLy2f3gH+27a5XSuXo6h7R3vqltl0PgZ80C8ZMKw98Bf8bqt6BEVi3svOh2PzMw==}
     engines: {node: '>=6.9.0'}
@@ -1138,6 +1579,16 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.14.3
+      '@babel/helper-plugin-utils': 7.16.7
+    dev: true
+
+  /@babel/plugin-transform-member-expression-literals/7.16.7_@babel+core@7.17.2:
+    resolution: {integrity: sha512-mBruRMbktKQwbxaJof32LT9KLy2f3gH+27a5XSuXo6h7R3vqltl0PgZ80C8ZMKw98Bf8bqt6BEVi3svOh2PzMw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.17.2
       '@babel/helper-plugin-utils': 7.16.7
     dev: true
 
@@ -1197,6 +1648,21 @@ packages:
       - supports-color
     dev: true
 
+  /@babel/plugin-transform-modules-commonjs/7.16.8_@babel+core@7.17.2:
+    resolution: {integrity: sha512-oflKPvsLT2+uKQopesJt3ApiaIS2HW+hzHFcwRNtyDGieAeC/dIHZX8buJQ2J2X1rxGPy4eRcUijm3qcSPjYcA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.17.2
+      '@babel/helper-module-transforms': 7.16.7
+      '@babel/helper-plugin-utils': 7.16.7
+      '@babel/helper-simple-access': 7.16.7
+      babel-plugin-dynamic-import-node: 2.3.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@babel/plugin-transform-modules-systemjs/7.16.7_@babel+core@7.14.3:
     resolution: {integrity: sha512-DuK5E3k+QQmnOqBR9UkusByy5WZWGRxfzV529s9nPra1GE7olmxfqO2FHobEOYSPIjPBTr4p66YDcjQnt8cBmw==}
     engines: {node: '>=6.9.0'}
@@ -1204,6 +1670,22 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.14.3
+      '@babel/helper-hoist-variables': 7.16.7
+      '@babel/helper-module-transforms': 7.16.7
+      '@babel/helper-plugin-utils': 7.16.7
+      '@babel/helper-validator-identifier': 7.16.7
+      babel-plugin-dynamic-import-node: 2.3.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@babel/plugin-transform-modules-systemjs/7.16.7_@babel+core@7.17.2:
+    resolution: {integrity: sha512-DuK5E3k+QQmnOqBR9UkusByy5WZWGRxfzV529s9nPra1GE7olmxfqO2FHobEOYSPIjPBTr4p66YDcjQnt8cBmw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.17.2
       '@babel/helper-hoist-variables': 7.16.7
       '@babel/helper-module-transforms': 7.16.7
       '@babel/helper-plugin-utils': 7.16.7
@@ -1226,6 +1708,19 @@ packages:
       - supports-color
     dev: true
 
+  /@babel/plugin-transform-modules-umd/7.16.7_@babel+core@7.17.2:
+    resolution: {integrity: sha512-EMh7uolsC8O4xhudF2F6wedbSHm1HHZ0C6aJ7K67zcDNidMzVcxWdGr+htW9n21klm+bOn+Rx4CBsAntZd3rEQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.17.2
+      '@babel/helper-module-transforms': 7.16.7
+      '@babel/helper-plugin-utils': 7.16.7
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@babel/plugin-transform-named-capturing-groups-regex/7.16.8_@babel+core@7.14.3:
     resolution: {integrity: sha512-j3Jw+n5PvpmhRR+mrgIh04puSANCk/T/UA3m3P1MjJkhlK906+ApHhDIqBQDdOgL/r1UYpz4GNclTXxyZrYGSw==}
     engines: {node: '>=6.9.0'}
@@ -1236,6 +1731,16 @@ packages:
       '@babel/helper-create-regexp-features-plugin': 7.17.0_@babel+core@7.14.3
     dev: true
 
+  /@babel/plugin-transform-named-capturing-groups-regex/7.16.8_@babel+core@7.17.2:
+    resolution: {integrity: sha512-j3Jw+n5PvpmhRR+mrgIh04puSANCk/T/UA3m3P1MjJkhlK906+ApHhDIqBQDdOgL/r1UYpz4GNclTXxyZrYGSw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.17.2
+      '@babel/helper-create-regexp-features-plugin': 7.17.0_@babel+core@7.17.2
+    dev: true
+
   /@babel/plugin-transform-new-target/7.16.7_@babel+core@7.14.3:
     resolution: {integrity: sha512-xiLDzWNMfKoGOpc6t3U+etCE2yRnn3SM09BXqWPIZOBpL2gvVrBWUKnsJx0K/ADi5F5YC5f8APFfWrz25TdlGg==}
     engines: {node: '>=6.9.0'}
@@ -1243,6 +1748,16 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.14.3
+      '@babel/helper-plugin-utils': 7.16.7
+    dev: true
+
+  /@babel/plugin-transform-new-target/7.16.7_@babel+core@7.17.2:
+    resolution: {integrity: sha512-xiLDzWNMfKoGOpc6t3U+etCE2yRnn3SM09BXqWPIZOBpL2gvVrBWUKnsJx0K/ADi5F5YC5f8APFfWrz25TdlGg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.17.2
       '@babel/helper-plugin-utils': 7.16.7
     dev: true
 
@@ -1267,6 +1782,19 @@ packages:
       - supports-color
     dev: true
 
+  /@babel/plugin-transform-object-super/7.16.7_@babel+core@7.17.2:
+    resolution: {integrity: sha512-14J1feiQVWaGvRxj2WjyMuXS2jsBkgB3MdSN5HuC2G5nRspa5RK9COcs82Pwy5BuGcjb+fYaUj94mYcOj7rCvw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.17.2
+      '@babel/helper-plugin-utils': 7.16.7
+      '@babel/helper-replace-supers': 7.16.7
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@babel/plugin-transform-parameters/7.16.7_@babel+core@7.14.3:
     resolution: {integrity: sha512-AT3MufQ7zZEhU2hwOA11axBnExW0Lszu4RL/tAlUJBuNoRak+wehQW8h6KcXOcgjY42fHtDxswuMhMjFEuv/aw==}
     engines: {node: '>=6.9.0'}
@@ -1274,6 +1802,16 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.14.3
+      '@babel/helper-plugin-utils': 7.16.7
+    dev: true
+
+  /@babel/plugin-transform-parameters/7.16.7_@babel+core@7.17.2:
+    resolution: {integrity: sha512-AT3MufQ7zZEhU2hwOA11axBnExW0Lszu4RL/tAlUJBuNoRak+wehQW8h6KcXOcgjY42fHtDxswuMhMjFEuv/aw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.17.2
       '@babel/helper-plugin-utils': 7.16.7
     dev: true
 
@@ -1287,6 +1825,16 @@ packages:
       '@babel/helper-plugin-utils': 7.16.7
     dev: true
 
+  /@babel/plugin-transform-property-literals/7.16.7_@babel+core@7.17.2:
+    resolution: {integrity: sha512-z4FGr9NMGdoIl1RqavCqGG+ZuYjfZ/hkCIeuH6Do7tXmSm0ls11nYVSJqFEUOSJbDab5wC6lRE/w6YjVcr6Hqw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.17.2
+      '@babel/helper-plugin-utils': 7.16.7
+    dev: true
+
   /@babel/plugin-transform-regenerator/7.16.7_@babel+core@7.14.3:
     resolution: {integrity: sha512-mF7jOgGYCkSJagJ6XCujSQg+6xC1M77/03K2oBmVJWoFGNUtnVJO4WHKJk3dnPC8HCcj4xBQP1Egm8DWh3Pb3Q==}
     engines: {node: '>=6.9.0'}
@@ -1297,6 +1845,16 @@ packages:
       regenerator-transform: 0.14.4
     dev: true
 
+  /@babel/plugin-transform-regenerator/7.16.7_@babel+core@7.17.2:
+    resolution: {integrity: sha512-mF7jOgGYCkSJagJ6XCujSQg+6xC1M77/03K2oBmVJWoFGNUtnVJO4WHKJk3dnPC8HCcj4xBQP1Egm8DWh3Pb3Q==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.17.2
+      regenerator-transform: 0.14.4
+    dev: true
+
   /@babel/plugin-transform-reserved-words/7.16.7_@babel+core@7.14.3:
     resolution: {integrity: sha512-KQzzDnZ9hWQBjwi5lpY5v9shmm6IVG0U9pB18zvMu2i4H90xpT4gmqwPYsn8rObiadYe2M0gmgsiOIF5A/2rtg==}
     engines: {node: '>=6.9.0'}
@@ -1304,6 +1862,16 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.14.3
+      '@babel/helper-plugin-utils': 7.16.7
+    dev: true
+
+  /@babel/plugin-transform-reserved-words/7.16.7_@babel+core@7.17.2:
+    resolution: {integrity: sha512-KQzzDnZ9hWQBjwi5lpY5v9shmm6IVG0U9pB18zvMu2i4H90xpT4gmqwPYsn8rObiadYe2M0gmgsiOIF5A/2rtg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.17.2
       '@babel/helper-plugin-utils': 7.16.7
     dev: true
 
@@ -1333,6 +1901,16 @@ packages:
       '@babel/helper-plugin-utils': 7.16.7
     dev: true
 
+  /@babel/plugin-transform-shorthand-properties/7.16.7_@babel+core@7.17.2:
+    resolution: {integrity: sha512-hah2+FEnoRoATdIb05IOXf+4GzXYTq75TVhIn1PewihbpyrNWUt2JbudKQOETWw6QpLe+AIUpJ5MVLYTQbeeUg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.17.2
+      '@babel/helper-plugin-utils': 7.16.7
+    dev: true
+
   /@babel/plugin-transform-spread/7.16.7_@babel+core@7.14.3:
     resolution: {integrity: sha512-+pjJpgAngb53L0iaA5gU/1MLXJIfXcYepLgXB3esVRf4fqmj8f2cxM3/FKaHsZms08hFQJkFccEWuIpm429TXg==}
     engines: {node: '>=6.9.0'}
@@ -1340,6 +1918,17 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.14.3
+      '@babel/helper-plugin-utils': 7.16.7
+      '@babel/helper-skip-transparent-expression-wrappers': 7.16.0
+    dev: true
+
+  /@babel/plugin-transform-spread/7.16.7_@babel+core@7.17.2:
+    resolution: {integrity: sha512-+pjJpgAngb53L0iaA5gU/1MLXJIfXcYepLgXB3esVRf4fqmj8f2cxM3/FKaHsZms08hFQJkFccEWuIpm429TXg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.17.2
       '@babel/helper-plugin-utils': 7.16.7
       '@babel/helper-skip-transparent-expression-wrappers': 7.16.0
     dev: true
@@ -1354,6 +1943,16 @@ packages:
       '@babel/helper-plugin-utils': 7.16.7
     dev: true
 
+  /@babel/plugin-transform-sticky-regex/7.16.7_@babel+core@7.17.2:
+    resolution: {integrity: sha512-NJa0Bd/87QV5NZZzTuZG5BPJjLYadeSZ9fO6oOUoL4iQx+9EEuw/eEM92SrsT19Yc2jgB1u1hsjqDtH02c3Drw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.17.2
+      '@babel/helper-plugin-utils': 7.16.7
+    dev: true
+
   /@babel/plugin-transform-template-literals/7.16.7_@babel+core@7.14.3:
     resolution: {integrity: sha512-VwbkDDUeenlIjmfNeDX/V0aWrQH2QiVyJtwymVQSzItFDTpxfyJh3EVaQiS0rIN/CqbLGr0VcGmuwyTdZtdIsA==}
     engines: {node: '>=6.9.0'}
@@ -1364,6 +1963,16 @@ packages:
       '@babel/helper-plugin-utils': 7.16.7
     dev: true
 
+  /@babel/plugin-transform-template-literals/7.16.7_@babel+core@7.17.2:
+    resolution: {integrity: sha512-VwbkDDUeenlIjmfNeDX/V0aWrQH2QiVyJtwymVQSzItFDTpxfyJh3EVaQiS0rIN/CqbLGr0VcGmuwyTdZtdIsA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.17.2
+      '@babel/helper-plugin-utils': 7.16.7
+    dev: true
+
   /@babel/plugin-transform-typeof-symbol/7.16.7_@babel+core@7.14.3:
     resolution: {integrity: sha512-p2rOixCKRJzpg9JB4gjnG4gjWkWa89ZoYUnl9snJ1cWIcTH/hvxZqfO+WjG6T8DRBpctEol5jw1O5rA8gkCokQ==}
     engines: {node: '>=6.9.0'}
@@ -1371,6 +1980,16 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.14.3
+      '@babel/helper-plugin-utils': 7.16.7
+    dev: true
+
+  /@babel/plugin-transform-typeof-symbol/7.16.7_@babel+core@7.17.2:
+    resolution: {integrity: sha512-p2rOixCKRJzpg9JB4gjnG4gjWkWa89ZoYUnl9snJ1cWIcTH/hvxZqfO+WjG6T8DRBpctEol5jw1O5rA8gkCokQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.17.2
       '@babel/helper-plugin-utils': 7.16.7
     dev: true
 
@@ -1406,6 +2025,16 @@ packages:
       '@babel/helper-plugin-utils': 7.16.7
     dev: true
 
+  /@babel/plugin-transform-unicode-escapes/7.16.7_@babel+core@7.17.2:
+    resolution: {integrity: sha512-TAV5IGahIz3yZ9/Hfv35TV2xEm+kaBDaZQCn2S/hG9/CZ0DktxJv9eKfPc7yYCvOYR4JGx1h8C+jcSOvgaaI/Q==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.17.2
+      '@babel/helper-plugin-utils': 7.16.7
+    dev: true
+
   /@babel/plugin-transform-unicode-regex/7.16.7_@babel+core@7.14.3:
     resolution: {integrity: sha512-oC5tYYKw56HO75KZVLQ+R/Nl3Hro9kf8iG0hXoaHP7tjAyCpvqBiSNe6vGrZni1Z6MggmUOC6A7VP7AVmw225Q==}
     engines: {node: '>=6.9.0'}
@@ -1414,6 +2043,17 @@ packages:
     dependencies:
       '@babel/core': 7.14.3
       '@babel/helper-create-regexp-features-plugin': 7.17.0_@babel+core@7.14.3
+      '@babel/helper-plugin-utils': 7.16.7
+    dev: true
+
+  /@babel/plugin-transform-unicode-regex/7.16.7_@babel+core@7.17.2:
+    resolution: {integrity: sha512-oC5tYYKw56HO75KZVLQ+R/Nl3Hro9kf8iG0hXoaHP7tjAyCpvqBiSNe6vGrZni1Z6MggmUOC6A7VP7AVmw225Q==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.17.2
+      '@babel/helper-create-regexp-features-plugin': 7.17.0_@babel+core@7.17.2
       '@babel/helper-plugin-utils': 7.16.7
     dev: true
 
@@ -1510,6 +2150,91 @@ packages:
       - supports-color
     dev: true
 
+  /@babel/preset-env/7.16.11_@babel+core@7.17.2:
+    resolution: {integrity: sha512-qcmWG8R7ZW6WBRPZK//y+E3Cli151B20W1Rv7ln27vuPaXU/8TKms6jFdiJtF7UDTxcrb7mZd88tAeK9LjdT8g==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/compat-data': 7.17.0
+      '@babel/core': 7.17.2
+      '@babel/helper-compilation-targets': 7.16.7_@babel+core@7.17.2
+      '@babel/helper-plugin-utils': 7.16.7
+      '@babel/helper-validator-option': 7.16.7
+      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.16.7_@babel+core@7.17.2
+      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.16.7_@babel+core@7.17.2
+      '@babel/plugin-proposal-async-generator-functions': 7.16.8_@babel+core@7.17.2
+      '@babel/plugin-proposal-class-properties': 7.16.7_@babel+core@7.17.2
+      '@babel/plugin-proposal-class-static-block': 7.16.7_@babel+core@7.17.2
+      '@babel/plugin-proposal-dynamic-import': 7.16.7_@babel+core@7.17.2
+      '@babel/plugin-proposal-export-namespace-from': 7.16.7_@babel+core@7.17.2
+      '@babel/plugin-proposal-json-strings': 7.16.7_@babel+core@7.17.2
+      '@babel/plugin-proposal-logical-assignment-operators': 7.16.7_@babel+core@7.17.2
+      '@babel/plugin-proposal-nullish-coalescing-operator': 7.16.7_@babel+core@7.17.2
+      '@babel/plugin-proposal-numeric-separator': 7.16.7_@babel+core@7.17.2
+      '@babel/plugin-proposal-object-rest-spread': 7.16.7_@babel+core@7.17.2
+      '@babel/plugin-proposal-optional-catch-binding': 7.16.7_@babel+core@7.17.2
+      '@babel/plugin-proposal-optional-chaining': 7.16.7_@babel+core@7.17.2
+      '@babel/plugin-proposal-private-methods': 7.16.11_@babel+core@7.17.2
+      '@babel/plugin-proposal-private-property-in-object': 7.16.7_@babel+core@7.17.2
+      '@babel/plugin-proposal-unicode-property-regex': 7.16.7_@babel+core@7.17.2
+      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.17.2
+      '@babel/plugin-syntax-class-properties': 7.12.13_@babel+core@7.17.2
+      '@babel/plugin-syntax-class-static-block': 7.14.5_@babel+core@7.17.2
+      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.17.2
+      '@babel/plugin-syntax-export-namespace-from': 7.8.3_@babel+core@7.17.2
+      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.17.2
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4_@babel+core@7.17.2
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.17.2
+      '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.17.2
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.17.2
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.17.2
+      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.17.2
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5_@babel+core@7.17.2
+      '@babel/plugin-syntax-top-level-await': 7.14.5_@babel+core@7.17.2
+      '@babel/plugin-transform-arrow-functions': 7.16.7_@babel+core@7.17.2
+      '@babel/plugin-transform-async-to-generator': 7.16.8_@babel+core@7.17.2
+      '@babel/plugin-transform-block-scoped-functions': 7.16.7_@babel+core@7.17.2
+      '@babel/plugin-transform-block-scoping': 7.16.7_@babel+core@7.17.2
+      '@babel/plugin-transform-classes': 7.16.7_@babel+core@7.17.2
+      '@babel/plugin-transform-computed-properties': 7.16.7_@babel+core@7.17.2
+      '@babel/plugin-transform-destructuring': 7.16.7_@babel+core@7.17.2
+      '@babel/plugin-transform-dotall-regex': 7.16.7_@babel+core@7.17.2
+      '@babel/plugin-transform-duplicate-keys': 7.16.7_@babel+core@7.17.2
+      '@babel/plugin-transform-exponentiation-operator': 7.16.7_@babel+core@7.17.2
+      '@babel/plugin-transform-for-of': 7.16.7_@babel+core@7.17.2
+      '@babel/plugin-transform-function-name': 7.16.7_@babel+core@7.17.2
+      '@babel/plugin-transform-literals': 7.16.7_@babel+core@7.17.2
+      '@babel/plugin-transform-member-expression-literals': 7.16.7_@babel+core@7.17.2
+      '@babel/plugin-transform-modules-amd': 7.16.7_@babel+core@7.17.2
+      '@babel/plugin-transform-modules-commonjs': 7.16.8_@babel+core@7.17.2
+      '@babel/plugin-transform-modules-systemjs': 7.16.7_@babel+core@7.17.2
+      '@babel/plugin-transform-modules-umd': 7.16.7_@babel+core@7.17.2
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.16.8_@babel+core@7.17.2
+      '@babel/plugin-transform-new-target': 7.16.7_@babel+core@7.17.2
+      '@babel/plugin-transform-object-super': 7.16.7_@babel+core@7.17.2
+      '@babel/plugin-transform-parameters': 7.16.7_@babel+core@7.17.2
+      '@babel/plugin-transform-property-literals': 7.16.7_@babel+core@7.17.2
+      '@babel/plugin-transform-regenerator': 7.16.7_@babel+core@7.17.2
+      '@babel/plugin-transform-reserved-words': 7.16.7_@babel+core@7.17.2
+      '@babel/plugin-transform-shorthand-properties': 7.16.7_@babel+core@7.17.2
+      '@babel/plugin-transform-spread': 7.16.7_@babel+core@7.17.2
+      '@babel/plugin-transform-sticky-regex': 7.16.7_@babel+core@7.17.2
+      '@babel/plugin-transform-template-literals': 7.16.7_@babel+core@7.17.2
+      '@babel/plugin-transform-typeof-symbol': 7.16.7_@babel+core@7.17.2
+      '@babel/plugin-transform-unicode-escapes': 7.16.7_@babel+core@7.17.2
+      '@babel/plugin-transform-unicode-regex': 7.16.7_@babel+core@7.17.2
+      '@babel/preset-modules': 0.1.5_@babel+core@7.17.2
+      '@babel/types': 7.17.0
+      babel-plugin-polyfill-corejs2: 0.3.1_@babel+core@7.17.2
+      babel-plugin-polyfill-corejs3: 0.5.2_@babel+core@7.17.2
+      babel-plugin-polyfill-regenerator: 0.3.1_@babel+core@7.17.2
+      core-js-compat: 3.21.0
+      semver: 6.3.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@babel/preset-modules/0.1.5_@babel+core@7.14.3:
     resolution: {integrity: sha512-A57th6YRG7oR3cq/yt/Y84MvGgE0eJG2F1JLhKuyG+jFxEgrd/HAMJatiFtmOiZurz+0DkrvbheCLaV5f2JfjA==}
     peerDependencies:
@@ -1519,6 +2244,19 @@ packages:
       '@babel/helper-plugin-utils': 7.16.7
       '@babel/plugin-proposal-unicode-property-regex': 7.16.7_@babel+core@7.14.3
       '@babel/plugin-transform-dotall-regex': 7.16.7_@babel+core@7.14.3
+      '@babel/types': 7.17.0
+      esutils: 2.0.2
+    dev: true
+
+  /@babel/preset-modules/0.1.5_@babel+core@7.17.2:
+    resolution: {integrity: sha512-A57th6YRG7oR3cq/yt/Y84MvGgE0eJG2F1JLhKuyG+jFxEgrd/HAMJatiFtmOiZurz+0DkrvbheCLaV5f2JfjA==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.17.2
+      '@babel/helper-plugin-utils': 7.16.7
+      '@babel/plugin-proposal-unicode-property-regex': 7.16.7_@babel+core@7.17.2
+      '@babel/plugin-transform-dotall-regex': 7.16.7_@babel+core@7.17.2
       '@babel/types': 7.17.0
       esutils: 2.0.2
     dev: true
@@ -1604,19 +2342,44 @@ packages:
       silent-error: 1.1.1
     dev: true
 
-  /@ember/test-helpers/1.7.1:
-    resolution: {integrity: sha512-+ioumnanSRJzZ0ZH30FIkB0r41UhVyuWQ9R9Yp1phDWJQDLumxg+25WDr40relwcH6z0Cn6LIEzeTVujO/0Rww==}
-    engines: {node: 6.* || 8.* || >= 10.*}
+  /@ember/test-helpers/2.6.0:
+    resolution: {integrity: sha512-N5sr3layWk60wB3maCy+/5hFHQRcTh8aqxcZTSs3Od9QkuHdWBtRgMGLP/35mXpJlgWuu3xqLpt6u3dGHc8gCg==}
+    engines: {node: 10.* || 12.* || 14.* || 15.* || >= 16.*}
     dependencies:
+      '@ember/test-waiters': 3.0.1
       broccoli-debug: 0.6.5
-      broccoli-funnel: 2.0.2
-      ember-assign-polyfill: 2.6.0
+      broccoli-funnel: 3.0.8
       ember-cli-babel: 7.26.11
-      ember-cli-htmlbars-inline-precompile: 2.1.0_ember-cli-babel@7.26.11
-      ember-test-waiters: 1.1.1
+      ember-cli-htmlbars: 5.7.2
+      ember-destroyable-polyfill: 2.0.3
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
+    dev: true
+
+  /@ember/test-waiters/3.0.1:
+    resolution: {integrity: sha512-LqV55mMiSuhAAWfbJdJf0bxHc22A/CiG8TKyZwpcSv4A1GJIpdlTvqHCrlcdV6T30+L0/uyj14upC3ayWmV0CQ==}
+    engines: {node: 10.* || 12.* || >= 14.*}
+    dependencies:
+      calculate-cache-key-for-tree: 2.0.0
+      ember-cli-babel: 7.26.11
+      ember-cli-version-checker: 5.1.2
+      semver: 7.3.5
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@embroider/shared-internals/1.2.0:
+    resolution: {integrity: sha512-11RfGuXxT+m2xPcpny/ENHjw53CuKPcrx7222LFQ53+I09hLxsvPCsH8be5E99LePDA46YGX41vxOxxfowD4OQ==}
+    engines: {node: 12.* || 14.* || >= 16}
+    dependencies:
+      babel-import-util: 1.1.0
+      ember-rfc176-data: 0.3.17
+      fs-extra: 9.1.0
+      lodash: 4.17.21
+      resolve-package-path: 4.0.3
+      semver: 7.3.5
+      typescript-memoize: 1.1.0
     dev: true
 
   /@eslint/eslintrc/0.4.3:
@@ -2151,6 +2914,10 @@ packages:
       '@types/istanbul-lib-report': 1.1.1
     dev: true
 
+  /@types/json-schema/7.0.9:
+    resolution: {integrity: sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==}
+    dev: true
+
   /@types/mime/2.0.1:
     resolution: {integrity: sha512-FwI9gX75FgVBJ7ywgnq/P7tw+/o1GUbtP0KzbtusLigAOgIgNISRK0ZPl4qertvXSIE8YbsVJueQ90cDt9YYyw==}
     dev: true
@@ -2203,6 +2970,141 @@ packages:
       '@types/yargs-parser': 13.0.0
     dev: true
 
+  /@webassemblyjs/ast/1.9.0:
+    resolution: {integrity: sha512-C6wW5L+b7ogSDVqymbkkvuW9kruN//YisMED04xzeBBqjHa2FYnmvOlS6Xj68xWQRgWvI9cIglsjFowH/RJyEA==}
+    dependencies:
+      '@webassemblyjs/helper-module-context': 1.9.0
+      '@webassemblyjs/helper-wasm-bytecode': 1.9.0
+      '@webassemblyjs/wast-parser': 1.9.0
+    dev: true
+
+  /@webassemblyjs/floating-point-hex-parser/1.9.0:
+    resolution: {integrity: sha512-TG5qcFsS8QB4g4MhrxK5TqfdNe7Ey/7YL/xN+36rRjl/BlGE/NcBvJcqsRgCP6Z92mRE+7N50pRIi8SmKUbcQA==}
+    dev: true
+
+  /@webassemblyjs/helper-api-error/1.9.0:
+    resolution: {integrity: sha512-NcMLjoFMXpsASZFxJ5h2HZRcEhDkvnNFOAKneP5RbKRzaWJN36NC4jqQHKwStIhGXu5mUWlUUk7ygdtrO8lbmw==}
+    dev: true
+
+  /@webassemblyjs/helper-buffer/1.9.0:
+    resolution: {integrity: sha512-qZol43oqhq6yBPx7YM3m9Bv7WMV9Eevj6kMi6InKOuZxhw+q9hOkvq5e/PpKSiLfyetpaBnogSbNCfBwyB00CA==}
+    dev: true
+
+  /@webassemblyjs/helper-code-frame/1.9.0:
+    resolution: {integrity: sha512-ERCYdJBkD9Vu4vtjUYe8LZruWuNIToYq/ME22igL+2vj2dQ2OOujIZr3MEFvfEaqKoVqpsFKAGsRdBSBjrIvZA==}
+    dependencies:
+      '@webassemblyjs/wast-printer': 1.9.0
+    dev: true
+
+  /@webassemblyjs/helper-fsm/1.9.0:
+    resolution: {integrity: sha512-OPRowhGbshCb5PxJ8LocpdX9Kl0uB4XsAjl6jH/dWKlk/mzsANvhwbiULsaiqT5GZGT9qinTICdj6PLuM5gslw==}
+    dev: true
+
+  /@webassemblyjs/helper-module-context/1.9.0:
+    resolution: {integrity: sha512-MJCW8iGC08tMk2enck1aPW+BE5Cw8/7ph/VGZxwyvGbJwjktKkDK7vy7gAmMDx88D7mhDTCNKAW5tED+gZ0W8g==}
+    dependencies:
+      '@webassemblyjs/ast': 1.9.0
+    dev: true
+
+  /@webassemblyjs/helper-wasm-bytecode/1.9.0:
+    resolution: {integrity: sha512-R7FStIzyNcd7xKxCZH5lE0Bqy+hGTwS3LJjuv1ZVxd9O7eHCedSdrId/hMOd20I+v8wDXEn+bjfKDLzTepoaUw==}
+    dev: true
+
+  /@webassemblyjs/helper-wasm-section/1.9.0:
+    resolution: {integrity: sha512-XnMB8l3ek4tvrKUUku+IVaXNHz2YsJyOOmz+MMkZvh8h1uSJpSen6vYnw3IoQ7WwEuAhL8Efjms1ZWjqh2agvw==}
+    dependencies:
+      '@webassemblyjs/ast': 1.9.0
+      '@webassemblyjs/helper-buffer': 1.9.0
+      '@webassemblyjs/helper-wasm-bytecode': 1.9.0
+      '@webassemblyjs/wasm-gen': 1.9.0
+    dev: true
+
+  /@webassemblyjs/ieee754/1.9.0:
+    resolution: {integrity: sha512-dcX8JuYU/gvymzIHc9DgxTzUUTLexWwt8uCTWP3otys596io0L5aW02Gb1RjYpx2+0Jus1h4ZFqjla7umFniTg==}
+    dependencies:
+      '@xtuc/ieee754': 1.2.0
+    dev: true
+
+  /@webassemblyjs/leb128/1.9.0:
+    resolution: {integrity: sha512-ENVzM5VwV1ojs9jam6vPys97B/S65YQtv/aanqnU7D8aSoHFX8GyhGg0CMfyKNIHBuAVjy3tlzd5QMMINa7wpw==}
+    dependencies:
+      '@xtuc/long': 4.2.2
+    dev: true
+
+  /@webassemblyjs/utf8/1.9.0:
+    resolution: {integrity: sha512-GZbQlWtopBTP0u7cHrEx+73yZKrQoBMpwkGEIqlacljhXCkVM1kMQge/Mf+csMJAjEdSwhOyLAS0AoR3AG5P8w==}
+    dev: true
+
+  /@webassemblyjs/wasm-edit/1.9.0:
+    resolution: {integrity: sha512-FgHzBm80uwz5M8WKnMTn6j/sVbqilPdQXTWraSjBwFXSYGirpkSWE2R9Qvz9tNiTKQvoKILpCuTjBKzOIm0nxw==}
+    dependencies:
+      '@webassemblyjs/ast': 1.9.0
+      '@webassemblyjs/helper-buffer': 1.9.0
+      '@webassemblyjs/helper-wasm-bytecode': 1.9.0
+      '@webassemblyjs/helper-wasm-section': 1.9.0
+      '@webassemblyjs/wasm-gen': 1.9.0
+      '@webassemblyjs/wasm-opt': 1.9.0
+      '@webassemblyjs/wasm-parser': 1.9.0
+      '@webassemblyjs/wast-printer': 1.9.0
+    dev: true
+
+  /@webassemblyjs/wasm-gen/1.9.0:
+    resolution: {integrity: sha512-cPE3o44YzOOHvlsb4+E9qSqjc9Qf9Na1OO/BHFy4OI91XDE14MjFN4lTMezzaIWdPqHnsTodGGNP+iRSYfGkjA==}
+    dependencies:
+      '@webassemblyjs/ast': 1.9.0
+      '@webassemblyjs/helper-wasm-bytecode': 1.9.0
+      '@webassemblyjs/ieee754': 1.9.0
+      '@webassemblyjs/leb128': 1.9.0
+      '@webassemblyjs/utf8': 1.9.0
+    dev: true
+
+  /@webassemblyjs/wasm-opt/1.9.0:
+    resolution: {integrity: sha512-Qkjgm6Anhm+OMbIL0iokO7meajkzQD71ioelnfPEj6r4eOFuqm4YC3VBPqXjFyyNwowzbMD+hizmprP/Fwkl2A==}
+    dependencies:
+      '@webassemblyjs/ast': 1.9.0
+      '@webassemblyjs/helper-buffer': 1.9.0
+      '@webassemblyjs/wasm-gen': 1.9.0
+      '@webassemblyjs/wasm-parser': 1.9.0
+    dev: true
+
+  /@webassemblyjs/wasm-parser/1.9.0:
+    resolution: {integrity: sha512-9+wkMowR2AmdSWQzsPEjFU7njh8HTO5MqO8vjwEHuM+AMHioNqSBONRdr0NQQ3dVQrzp0s8lTcYqzUdb7YgELA==}
+    dependencies:
+      '@webassemblyjs/ast': 1.9.0
+      '@webassemblyjs/helper-api-error': 1.9.0
+      '@webassemblyjs/helper-wasm-bytecode': 1.9.0
+      '@webassemblyjs/ieee754': 1.9.0
+      '@webassemblyjs/leb128': 1.9.0
+      '@webassemblyjs/utf8': 1.9.0
+    dev: true
+
+  /@webassemblyjs/wast-parser/1.9.0:
+    resolution: {integrity: sha512-qsqSAP3QQ3LyZjNC/0jBJ/ToSxfYJ8kYyuiGvtn/8MK89VrNEfwj7BPQzJVHi0jGTRK2dGdJ5PRqhtjzoww+bw==}
+    dependencies:
+      '@webassemblyjs/ast': 1.9.0
+      '@webassemblyjs/floating-point-hex-parser': 1.9.0
+      '@webassemblyjs/helper-api-error': 1.9.0
+      '@webassemblyjs/helper-code-frame': 1.9.0
+      '@webassemblyjs/helper-fsm': 1.9.0
+      '@xtuc/long': 4.2.2
+    dev: true
+
+  /@webassemblyjs/wast-printer/1.9.0:
+    resolution: {integrity: sha512-2J0nE95rHXHyQ24cWjMKJ1tqB/ds8z/cyeOZxJhcb+rW+SQASVjuznUSmdz5GpVJTzU8JkhYut0D3siFDD6wsA==}
+    dependencies:
+      '@webassemblyjs/ast': 1.9.0
+      '@webassemblyjs/wast-parser': 1.9.0
+      '@xtuc/long': 4.2.2
+    dev: true
+
+  /@xtuc/ieee754/1.2.0:
+    resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
+    dev: true
+
+  /@xtuc/long/4.2.2:
+    resolution: {integrity: sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==}
+    dev: true
+
   /abab/2.0.5:
     resolution: {integrity: sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==}
     dev: true
@@ -2241,6 +3143,12 @@ packages:
 
   /acorn/5.7.4:
     resolution: {integrity: sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+    dev: true
+
+  /acorn/6.4.2:
+    resolution: {integrity: sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==}
     engines: {node: '>=0.4.0'}
     hasBin: true
     dev: true
@@ -2301,6 +3209,22 @@ packages:
       indent-string: 4.0.0
     dev: true
 
+  /ajv-errors/1.0.1_ajv@6.12.4:
+    resolution: {integrity: sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==}
+    peerDependencies:
+      ajv: '>=5.0.0'
+    dependencies:
+      ajv: 6.12.4
+    dev: true
+
+  /ajv-keywords/3.5.2_ajv@6.12.4:
+    resolution: {integrity: sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==}
+    peerDependencies:
+      ajv: ^6.9.1
+    dependencies:
+      ajv: 6.12.4
+    dev: true
+
   /ajv/6.12.4:
     resolution: {integrity: sha512-eienB2c9qVQs2KWexhkrdMLVDoIQCz5KSeLxwg9Lzk4DOfBtIK9PQwwufcsn1jjGuf9WZmqPMbGxOzfcuphJCQ==}
     dependencies:
@@ -2317,12 +3241,6 @@ packages:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
       uri-js: 4.2.2
-    dev: true
-
-  /amd-name-resolver/1.2.0:
-    resolution: {integrity: sha512-hlSTWGS1t6/xq5YCed7YALg7tKZL3rkl7UwEZ/eCIkn8JxmM6fU6Qs/1hwtjQqfuYxlffuUcgYEm0f5xP4YKaA==}
-    dependencies:
-      ensure-posix-path: 1.1.1
     dev: true
 
   /amd-name-resolver/1.3.1:
@@ -2441,6 +3359,14 @@ packages:
       picomatch: 2.3.1
     dev: true
 
+  /anymatch/3.1.2:
+    resolution: {integrity: sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==}
+    engines: {node: '>= 8'}
+    dependencies:
+      normalize-path: 3.0.0
+      picomatch: 2.3.1
+    dev: true
+
   /aproba/1.2.0:
     resolution: {integrity: sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==}
     dev: true
@@ -2521,6 +3447,22 @@ packages:
     resolution: {integrity: sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog==}
     dev: true
 
+  /asn1.js/5.4.1:
+    resolution: {integrity: sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==}
+    dependencies:
+      bn.js: 4.12.0
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
+      safer-buffer: 2.1.2
+    dev: true
+
+  /assert/1.5.0:
+    resolution: {integrity: sha512-EDsgawzwoun2CZkCgtxJbv392v4nbk9XDD06zI+kQYoBM/3RBWLlEyJARDOmhAAosBjWACEkKL6S+lIZtcAubA==}
+    dependencies:
+      object-assign: 4.1.1
+      util: 0.10.3
+    dev: true
+
   /assertion-error/1.1.0:
     resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
     dev: true
@@ -2567,6 +3509,11 @@ packages:
       - supports-color
     dev: true
 
+  /async-each/1.0.3:
+    resolution: {integrity: sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==}
+    dev: true
+    optional: true
+
   /async-promise-queue/1.0.4:
     resolution: {integrity: sha512-GQ5X3DT+TefYuFPHdvIPXFTlKnh39U7dwtl+aUBGeKjMea9nBpv3c91DXgeyBQmY07vQ97f3Sr9XHqkamEameQ==}
     dependencies:
@@ -2609,6 +3556,30 @@ packages:
 
   /babel-core/6.26.0:
     resolution: {integrity: sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=}
+    dependencies:
+      babel-code-frame: 6.26.0
+      babel-generator: 6.26.1
+      babel-helpers: 6.24.1
+      babel-messages: 6.23.0
+      babel-register: 6.26.0
+      babel-runtime: 6.26.0
+      babel-template: 6.26.0
+      babel-traverse: 6.26.0
+      babel-types: 6.26.0
+      babylon: 6.18.0
+      convert-source-map: 1.7.0
+      debug: 2.6.9
+      json5: 0.5.1
+      lodash: 4.17.21
+      minimatch: 3.0.4
+      path-is-absolute: 1.0.1
+      private: 0.1.8
+      slash: 1.0.0
+      source-map: 0.5.7
+    dev: true
+
+  /babel-core/6.26.3:
+    resolution: {integrity: sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==}
     dependencies:
       babel-code-frame: 6.26.0
       babel-generator: 6.26.1
@@ -2745,6 +3716,11 @@ packages:
       babel-template: 6.26.0
     dev: true
 
+  /babel-import-util/1.1.0:
+    resolution: {integrity: sha512-sfzgAiJsUT1es9yrHAuJZuJfBkkOE7Og6rovAIwK/gNJX6MjDfWTprbPngdJZTd5ye4F3FvpvpQmvKXObRzVYA==}
+    engines: {node: '>= 12.*'}
+    dev: true
+
   /babel-jest/27.5.1_@babel+core@7.17.2:
     resolution: {integrity: sha512-cdQ5dXjGRd0IBRATiQ4mZGlGlRE8kJpjPOixdNRdT+m3UcNqmYWN6rK6nvtXYfY3D76cb8s/O1Ss8ea24PIwcg==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
@@ -2762,6 +3738,21 @@ packages:
       slash: 3.0.0
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /babel-loader/8.2.3_60b7ed408fec1293d95f86d9ceaa88ca:
+    resolution: {integrity: sha512-n4Zeta8NC3QAsuyiizu0GkmRcQ6clkV9WFUnUf1iXP//IeSKbWjofW3UHyZVwlOB4y039YQKefawyTn64Zwbuw==}
+    engines: {node: '>= 8.9'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+      webpack: '>=2'
+    dependencies:
+      '@babel/core': 7.17.2
+      find-cache-dir: 3.3.2
+      loader-utils: 1.4.0
+      make-dir: 3.1.0
+      schema-utils: 2.7.1
+      webpack: 4.46.0
     dev: true
 
   /babel-messages/6.23.0:
@@ -2817,13 +3808,6 @@ packages:
       '@ember-data/rfc395-data': 0.0.4
     dev: true
 
-  /babel-plugin-ember-modules-api-polyfill/2.13.4:
-    resolution: {integrity: sha512-uxQPkEQAzCYdwhZk16O9m1R4xtCRNy4oEUTBrccOPfzlIahRZJic/JeP/ZEL0BC6Mfq6r55eOg6gMF/zdFoCvA==}
-    engines: {node: 6.* || 8.* || >= 10.*}
-    dependencies:
-      ember-rfc176-data: 0.3.17
-    dev: true
-
   /babel-plugin-ember-modules-api-polyfill/3.5.0:
     resolution: {integrity: sha512-pJajN/DkQUnStw0Az8c6khVcMQHgzqWr61lLNtVeu0g61LRW0k9jyK7vaedrHDWGe/Qe8sxG5wpiyW9NsMqFzA==}
     engines: {node: 6.* || 8.* || >= 10.*}
@@ -2837,11 +3821,6 @@ packages:
     dependencies:
       '@babel/types': 7.17.0
       lodash: 4.17.21
-    dev: true
-
-  /babel-plugin-htmlbars-inline-precompile/1.0.0:
-    resolution: {integrity: sha512-4jvKEHR1bAX03hBDZ94IXsYCj3bwk9vYsn6ux6JZNL2U5pvzCWjqyrGahfsGNrhERyxw8IqcirOi9Q6WCo3dkQ==}
-    engines: {node: '>= 4'}
     dev: true
 
   /babel-plugin-htmlbars-inline-precompile/2.1.1:
@@ -2927,6 +3906,19 @@ packages:
       - supports-color
     dev: true
 
+  /babel-plugin-polyfill-corejs2/0.3.1_@babel+core@7.17.2:
+    resolution: {integrity: sha512-v7/T6EQcNfVLfcN2X8Lulb7DjprieyLWJK/zOWH5DUYcAgex9sP3h25Q+DLsX9TloXe3y1O8l2q2Jv9q8UVB9w==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/compat-data': 7.17.0
+      '@babel/core': 7.17.2
+      '@babel/helper-define-polyfill-provider': 0.3.1_@babel+core@7.17.2
+      semver: 6.3.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /babel-plugin-polyfill-corejs3/0.1.7_@babel+core@7.14.3:
     resolution: {integrity: sha512-u+gbS9bbPhZWEeyy1oR/YaaSpod/KDT07arZHb80aTpl8H5ZBq+uN1nN9/xtX7jQyfLdPfoqI4Rue/MQSWJquw==}
     peerDependencies:
@@ -2946,6 +3938,18 @@ packages:
     dependencies:
       '@babel/core': 7.14.3
       '@babel/helper-define-polyfill-provider': 0.3.1_@babel+core@7.14.3
+      core-js-compat: 3.21.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /babel-plugin-polyfill-corejs3/0.5.2_@babel+core@7.17.2:
+    resolution: {integrity: sha512-G3uJih0XWiID451fpeFaYGVuxHEjzKTHtc9uGFEjR6hHrvNzeS/PX+LLLcetJcytsB5m4j+K3o/EpXJNb/5IEQ==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.17.2
+      '@babel/helper-define-polyfill-provider': 0.3.1_@babel+core@7.17.2
       core-js-compat: 3.21.0
     transitivePeerDependencies:
       - supports-color
@@ -2973,8 +3977,23 @@ packages:
       - supports-color
     dev: true
 
+  /babel-plugin-polyfill-regenerator/0.3.1_@babel+core@7.17.2:
+    resolution: {integrity: sha512-Y2B06tvgHYt1x0yz17jGkGeeMr5FeKUu+ASJ+N6nB5lQ8Dapfg42i0OVrf8PNGJ3zKL4A23snMi1IRwrqqND7A==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.17.2
+      '@babel/helper-define-polyfill-provider': 0.3.1_@babel+core@7.17.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /babel-plugin-syntax-async-functions/6.13.0:
     resolution: {integrity: sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=}
+    dev: true
+
+  /babel-plugin-syntax-dynamic-import/6.18.0:
+    resolution: {integrity: sha1-jWomIpyDdFqZgqRBBRVyyqF5sdo=}
     dev: true
 
   /babel-plugin-syntax-exponentiation-operator/6.13.0:
@@ -3182,14 +4201,6 @@ packages:
       babel-types: 6.26.0
     dev: true
 
-  /babel-polyfill/6.26.0:
-    resolution: {integrity: sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=}
-    dependencies:
-      babel-runtime: 6.26.0
-      core-js: 2.6.10
-      regenerator-runtime: 0.10.5
-    dev: true
-
   /babel-preset-current-node-syntax/1.0.0_@babel+core@7.17.2:
     resolution: {integrity: sha512-mGkvkpocWJes1CmMKtgGUwCeeq0pOhALyymozzDWYomHTbDLwueDYG6p4TK1YOeYHCzBzYPsWkgTto10JubI1Q==}
     peerDependencies:
@@ -3259,7 +4270,7 @@ packages:
   /babel-register/6.26.0:
     resolution: {integrity: sha1-btAhFz4vy0htestFxgCahW9kcHE=}
     dependencies:
-      babel-core: 6.26.0
+      babel-core: 6.26.3
       babel-runtime: 6.26.0
       core-js: 2.6.10
       home-or-tmp: 2.0.0
@@ -3345,6 +4356,10 @@ packages:
     engines: {node: '>= 0.6.0'}
     dev: true
 
+  /base64-js/1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+    dev: true
+
   /base64id/2.0.0:
     resolution: {integrity: sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==}
     engines: {node: ^4.5.0 || >= 5.9}
@@ -3357,10 +4372,33 @@ packages:
       safe-buffer: 5.1.2
     dev: true
 
+  /big.js/5.2.2:
+    resolution: {integrity: sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==}
+    dev: true
+
+  /binary-extensions/1.13.1:
+    resolution: {integrity: sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+    optional: true
+
+  /binary-extensions/2.2.0:
+    resolution: {integrity: sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==}
+    engines: {node: '>=8'}
+    dev: true
+    optional: true
+
   /binaryextensions/2.3.0:
     resolution: {integrity: sha512-nAihlQsYGyc5Bwq6+EsubvANYGExeJKHDO3RjnvwU042fawQTQfM3Kxn7IHUXQOz4bzfwsGYYHGSvXyW4zOGLg==}
     engines: {node: '>=0.8'}
     dev: true
+
+  /bindings/1.5.0:
+    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+    dependencies:
+      file-uri-to-path: 1.0.0
+    dev: true
+    optional: true
 
   /blank-object/1.0.2:
     resolution: {integrity: sha1-+ZB5P76ajI3QE/syGUIL7IHV9Lk=}
@@ -3372,6 +4410,18 @@ packages:
 
   /bluebird/3.5.1:
     resolution: {integrity: sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==}
+    dev: true
+
+  /bluebird/3.7.2:
+    resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
+    dev: true
+
+  /bn.js/4.12.0:
+    resolution: {integrity: sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==}
+    dev: true
+
+  /bn.js/5.2.0:
+    resolution: {integrity: sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==}
     dev: true
 
   /body-parser/1.19.0:
@@ -3403,7 +4453,7 @@ packages:
     resolution: {integrity: sha512-MVyyUk3d1S7d2cl6YISViwJBc2VXCkxF5AUFykvN0PQj5FsUiMNSgAYTso18oRFfyZ6XEtjrgg9MAaufHbOwNw==}
     engines: {node: '>=0.8.0'}
     dependencies:
-      graceful-fs: 4.2.9
+      graceful-fs: 4.2.4
       minimist: 0.2.1
       mout: 1.1.0
       osenv: 0.1.4
@@ -3461,22 +4511,6 @@ packages:
     dependencies:
       broccoli-plugin: 1.3.1
       symlink-or-copy: 1.3.1
-    dev: true
-
-  /broccoli-babel-transpiler/6.5.0:
-    resolution: {integrity: sha512-c5OLGY40Sdmv6rP230Jt8yoK49BHfOw1LXiDMu9EC9k2U6sqlpNRK78SzvByQ8IzKtBYUfeWCxeZHcvW+gH7VQ==}
-    engines: {node: '>= 4'}
-    dependencies:
-      babel-core: 6.26.0
-      broccoli-funnel: 2.0.2
-      broccoli-merge-trees: 2.0.0
-      broccoli-persistent-filter: 1.4.3
-      clone: 2.1.2
-      hash-for-dep: 1.5.1
-      heimdalljs-logger: 0.1.10
-      json-stable-stringify: 1.0.1
-      rsvp: 4.8.5
-      workerpool: 2.3.0
     dev: true
 
   /broccoli-babel-transpiler/7.8.0:
@@ -3828,10 +4862,6 @@ packages:
       heimdalljs: 0.2.6
     dev: true
 
-  /broccoli-source/1.1.0:
-    resolution: {integrity: sha1-VPDoLItz9GWAy7xPV48LMvyo+Ak=}
-    dev: true
-
   /broccoli-source/2.1.2:
     resolution: {integrity: sha512-1lLayO4wfS0c0Sj50VfHJXNWf94FYY0WUhxj0R77thbs6uWI7USiOWFqQV5dRmhAJnoKaGN4WyLGQbgjgiYFwQ==}
     engines: {node: 6.* || 8.* || >= 10.*}
@@ -3898,8 +4928,67 @@ packages:
       - supports-color
     dev: true
 
+  /brorand/1.1.0:
+    resolution: {integrity: sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=}
+    dev: true
+
   /browser-process-hrtime/1.0.0:
     resolution: {integrity: sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==}
+    dev: true
+
+  /browserify-aes/1.2.0:
+    resolution: {integrity: sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==}
+    dependencies:
+      buffer-xor: 1.0.3
+      cipher-base: 1.0.4
+      create-hash: 1.2.0
+      evp_bytestokey: 1.0.3
+      inherits: 2.0.4
+      safe-buffer: 5.2.1
+    dev: true
+
+  /browserify-cipher/1.0.1:
+    resolution: {integrity: sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==}
+    dependencies:
+      browserify-aes: 1.2.0
+      browserify-des: 1.0.2
+      evp_bytestokey: 1.0.3
+    dev: true
+
+  /browserify-des/1.0.2:
+    resolution: {integrity: sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==}
+    dependencies:
+      cipher-base: 1.0.4
+      des.js: 1.0.1
+      inherits: 2.0.4
+      safe-buffer: 5.2.1
+    dev: true
+
+  /browserify-rsa/4.1.0:
+    resolution: {integrity: sha512-AdEER0Hkspgno2aR97SAf6vi0y0k8NuOpGnVH3O99rcA5Q6sh8QxcngtHuJ6uXwnfAXNM4Gn1Gb7/MV1+Ymbog==}
+    dependencies:
+      bn.js: 5.2.0
+      randombytes: 2.1.0
+    dev: true
+
+  /browserify-sign/4.2.1:
+    resolution: {integrity: sha512-/vrA5fguVAKKAVTNJjgSm1tRQDHUU6DbwO9IROu/0WAzC8PKhucDSh18J0RMvVeHAn5puMd+QHC2erPRNf8lmg==}
+    dependencies:
+      bn.js: 5.2.0
+      browserify-rsa: 4.1.0
+      create-hash: 1.2.0
+      create-hmac: 1.1.7
+      elliptic: 6.5.4
+      inherits: 2.0.4
+      parse-asn1: 5.1.6
+      readable-stream: 3.6.0
+      safe-buffer: 5.2.1
+    dev: true
+
+  /browserify-zlib/0.2.0:
+    resolution: {integrity: sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==}
+    dependencies:
+      pako: 1.0.11
     dev: true
 
   /browserslist/3.2.8:
@@ -3932,9 +5021,25 @@ packages:
     resolution: {integrity: sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==}
     dev: true
 
+  /buffer-xor/1.0.3:
+    resolution: {integrity: sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=}
+    dev: true
+
+  /buffer/4.9.2:
+    resolution: {integrity: sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==}
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+      isarray: 1.0.0
+    dev: true
+
   /builtin-modules/2.0.0:
     resolution: {integrity: sha512-3U5kUA5VPsRUA3nofm/BXX7GVHKfxz0hOBAPxXrIvHzlDRkQVqEn6yi8QJegxl4LzOHLdvb7XF5dVawa/VVYBg==}
     engines: {node: '>=4'}
+    dev: true
+
+  /builtin-status-codes/3.0.0:
+    resolution: {integrity: sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=}
     dev: true
 
   /builtins/1.0.3:
@@ -3953,6 +5058,26 @@ packages:
   /bytes/3.1.0:
     resolution: {integrity: sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==}
     engines: {node: '>= 0.8'}
+    dev: true
+
+  /cacache/12.0.4:
+    resolution: {integrity: sha512-a0tMB40oefvuInr4Cwb3GerbL9xTj1D5yg0T5xrjGCGyfvbxseIXX7BAO/u/hIXdafzOI5JC3wDwHyf24buOAQ==}
+    dependencies:
+      bluebird: 3.7.2
+      chownr: 1.1.4
+      figgy-pudding: 3.5.2
+      glob: 7.2.0
+      graceful-fs: 4.2.9
+      infer-owner: 1.0.4
+      lru-cache: 5.1.1
+      mississippi: 3.0.0
+      mkdirp: 0.5.5
+      move-concurrently: 1.0.1
+      promise-inflight: 1.0.1
+      rimraf: 2.7.1
+      ssri: 6.0.2
+      unique-filename: 1.1.1
+      y18n: 4.0.1
     dev: true
 
   /cacache/14.0.0:
@@ -4123,6 +5248,43 @@ packages:
     resolution: {integrity: sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=}
     dev: true
 
+  /chokidar/2.1.8:
+    resolution: {integrity: sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==}
+    deprecated: Chokidar 2 does not receive security updates since 2019. Upgrade to chokidar 3 with 15x fewer dependencies
+    dependencies:
+      anymatch: 2.0.0
+      async-each: 1.0.3
+      braces: 2.3.2
+      glob-parent: 3.1.0
+      inherits: 2.0.4
+      is-binary-path: 1.0.1
+      is-glob: 4.0.1
+      normalize-path: 3.0.0
+      path-is-absolute: 1.0.1
+      readdirp: 2.2.1
+      upath: 1.2.0
+    optionalDependencies:
+      fsevents: 1.2.13
+    dev: true
+    optional: true
+
+  /chokidar/3.5.3:
+    resolution: {integrity: sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==}
+    engines: {node: '>= 8.10.0'}
+    requiresBuild: true
+    dependencies:
+      anymatch: 3.1.2
+      braces: 3.0.2
+      glob-parent: 5.1.2
+      is-binary-path: 2.1.0
+      is-glob: 4.0.1
+      normalize-path: 3.0.0
+      readdirp: 3.6.0
+    optionalDependencies:
+      fsevents: 2.3.2
+    dev: true
+    optional: true
+
   /chownr/1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
     dev: true
@@ -4132,8 +5294,20 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
+  /chrome-trace-event/1.0.3:
+    resolution: {integrity: sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==}
+    engines: {node: '>=6.0'}
+    dev: true
+
   /ci-info/3.3.0:
     resolution: {integrity: sha512-riT/3vI5YpVH6/qomlDnJow6TBee2PBKSEpx3O32EGPYbWGIRsIlGRms3Sm74wYE1JMo8RnO04Hb12+v1J5ICw==}
+    dev: true
+
+  /cipher-base/1.0.4:
+    resolution: {integrity: sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==}
+    dependencies:
+      inherits: 2.0.4
+      safe-buffer: 5.2.1
     dev: true
 
   /cjs-module-lexer/1.2.2:
@@ -4335,18 +5509,12 @@ packages:
       delayed-stream: 1.0.0
     dev: true
 
-  /commander/0.6.1:
-    resolution: {integrity: sha1-+mihT2qUXVTbvlDYzbMyDp47GgY=}
-    engines: {node: '>= 0.4.x'}
-    dev: true
-
   /commander/2.14.1:
     resolution: {integrity: sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw==}
     dev: true
 
-  /commander/2.3.0:
-    resolution: {integrity: sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM=}
-    engines: {node: '>= 0.6.x'}
+  /commander/2.20.3:
+    resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
     dev: true
 
   /commander/2.8.1:
@@ -4361,9 +5529,18 @@ packages:
     engines: {node: '>= 6'}
     dev: true
 
+  /commander/7.2.0:
+    resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
+    engines: {node: '>= 10'}
+    dev: true
+
   /common-tags/1.8.0:
     resolution: {integrity: sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw==}
     engines: {node: '>=4.0.0'}
+    dev: true
+
+  /commondir/1.0.1:
+    resolution: {integrity: sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=}
     dev: true
 
   /component-bind/1.0.0:
@@ -4406,12 +5583,22 @@ packages:
     resolution: {integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=}
     dev: true
 
+  /concat-stream/1.6.2:
+    resolution: {integrity: sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==}
+    engines: {'0': node >= 0.8}
+    dependencies:
+      buffer-from: 1.1.1
+      inherits: 2.0.4
+      readable-stream: 2.3.6
+      typedarray: 0.0.6
+    dev: true
+
   /configstore/5.0.1:
     resolution: {integrity: sha512-aMKprgk5YhBNyH25hj8wGt2+D52Sw1DRRIzqBwLp2Ya9mFmY8KPvvtvmna8SxVR9JMZ4kzMD68N22vlaRpkeFA==}
     engines: {node: '>=8'}
     dependencies:
       dot-prop: 5.2.0
-      graceful-fs: 4.2.9
+      graceful-fs: 4.2.4
       make-dir: 3.0.0
       unique-string: 2.0.0
       write-file-atomic: 3.0.1
@@ -4426,6 +5613,10 @@ packages:
       finalhandler: 1.1.0
       parseurl: 1.3.3
       utils-merge: 1.0.1
+    dev: true
+
+  /console-browserify/1.2.0:
+    resolution: {integrity: sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==}
     dev: true
 
   /console-control-strings/1.1.0:
@@ -4448,6 +5639,10 @@ packages:
     engines: {node: '>= 0.10.0'}
     dependencies:
       bluebird: 3.5.1
+    dev: true
+
+  /constants-browserify/1.0.0:
+    resolution: {integrity: sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=}
     dev: true
 
   /content-disposition/0.5.3:
@@ -4526,6 +5721,34 @@ packages:
     resolution: {integrity: sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=}
     dev: true
 
+  /create-ecdh/4.0.4:
+    resolution: {integrity: sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==}
+    dependencies:
+      bn.js: 4.12.0
+      elliptic: 6.5.4
+    dev: true
+
+  /create-hash/1.2.0:
+    resolution: {integrity: sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==}
+    dependencies:
+      cipher-base: 1.0.4
+      inherits: 2.0.4
+      md5.js: 1.3.5
+      ripemd160: 2.0.2
+      sha.js: 2.4.11
+    dev: true
+
+  /create-hmac/1.1.7:
+    resolution: {integrity: sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==}
+    dependencies:
+      cipher-base: 1.0.4
+      create-hash: 1.2.0
+      inherits: 2.0.4
+      ripemd160: 2.0.2
+      safe-buffer: 5.2.1
+      sha.js: 2.4.11
+    dev: true
+
   /cross-spawn/5.1.0:
     resolution: {integrity: sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=}
     dependencies:
@@ -4554,6 +5777,22 @@ packages:
       which: 2.0.2
     dev: true
 
+  /crypto-browserify/3.12.0:
+    resolution: {integrity: sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==}
+    dependencies:
+      browserify-cipher: 1.0.1
+      browserify-sign: 4.2.1
+      create-ecdh: 4.0.4
+      create-hash: 1.2.0
+      create-hmac: 1.1.7
+      diffie-hellman: 5.0.3
+      inherits: 2.0.4
+      pbkdf2: 3.1.2
+      public-encrypt: 4.0.3
+      randombytes: 2.1.0
+      randomfill: 1.0.4
+    dev: true
+
   /crypto-random-string/2.0.0:
     resolution: {integrity: sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==}
     engines: {node: '>=8'}
@@ -4574,6 +5813,10 @@ packages:
       cssom: 0.3.8
     dev: true
 
+  /cyclist/1.0.1:
+    resolution: {integrity: sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=}
+    dev: true
+
   /d/1.0.0:
     resolution: {integrity: sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=}
     dependencies:
@@ -4591,12 +5834,6 @@ packages:
       abab: 2.0.5
       whatwg-mimetype: 2.3.0
       whatwg-url: 8.7.0
-    dev: true
-
-  /debug/2.2.0:
-    resolution: {integrity: sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=}
-    dependencies:
-      ms: 0.7.1
     dev: true
 
   /debug/2.6.9:
@@ -4746,6 +5983,13 @@ packages:
     engines: {node: '>= 0.8'}
     dev: true
 
+  /des.js/1.0.1:
+    resolution: {integrity: sha512-Q0I4pfFrv2VPd34/vfLrFOoRmlYj3OV50i7fskps1jZWK1kApMWWT9G6RRUeYedLcBDIhnSDaUvJMb3AhUlaEA==}
+    dependencies:
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
+    dev: true
+
   /destroy/1.0.4:
     resolution: {integrity: sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=}
     dev: true
@@ -4777,14 +6021,17 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dev: true
 
-  /diff/1.4.0:
-    resolution: {integrity: sha1-fyjS657nsVqX79ic5j3P2qPMur8=}
-    engines: {node: '>=0.3.1'}
-    dev: true
-
   /diff/5.0.0:
     resolution: {integrity: sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==}
     engines: {node: '>=0.3.1'}
+    dev: true
+
+  /diffie-hellman/5.0.3:
+    resolution: {integrity: sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==}
+    dependencies:
+      bn.js: 4.12.0
+      miller-rabin: 4.0.1
+      randombytes: 2.1.0
     dev: true
 
   /dir-glob/3.0.1:
@@ -4799,6 +6046,11 @@ packages:
     engines: {node: '>=6.0.0'}
     dependencies:
       esutils: 2.0.2
+    dev: true
+
+  /domain-browser/1.2.0:
+    resolution: {integrity: sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==}
+    engines: {node: '>=0.4', npm: '>=1.2'}
     dev: true
 
   /domexception/2.0.1:
@@ -4817,6 +6069,15 @@ packages:
 
   /duplexer3/0.1.4:
     resolution: {integrity: sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=}
+    dev: true
+
+  /duplexify/3.7.1:
+    resolution: {integrity: sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==}
+    dependencies:
+      end-of-stream: 1.4.1
+      inherits: 2.0.4
+      readable-stream: 2.3.6
+      stream-shift: 1.0.1
     dev: true
 
   /editions/1.3.4:
@@ -4840,40 +6101,60 @@ packages:
     resolution: {integrity: sha512-cId+QwWrV8R1UawO6b9BR1hnkJ4EJPCPAr4h315vliHUtVUJDk39Sg1PMNnaWKfj5x+93ssjeJ9LKL6r8LaMiA==}
     dev: true
 
-  /ember-assign-polyfill/2.6.0:
-    resolution: {integrity: sha512-Y8NzOmHI/g4PuJ+xC14eTYiQbigNYddyHB8FY2kuQMxThTEIDE7SJtgttJrYYcPciOu0Tnb5ff36iO46LeiXkw==}
-    engines: {node: 6.* || 8.* || >= 10.*}
+  /elliptic/6.5.4:
+    resolution: {integrity: sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==}
     dependencies:
-      ember-cli-babel: 6.18.0
-      ember-cli-version-checker: 2.1.2
+      bn.js: 4.12.0
+      brorand: 1.1.0
+      hash.js: 1.1.7
+      hmac-drbg: 1.0.1
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
+      minimalistic-crypto-utils: 1.0.1
+    dev: true
+
+  /ember-auto-import/1.12.1:
+    resolution: {integrity: sha512-Jm0vWKNAy/wYMrdSQIrG8sRsvarIRHZ2sS/CGhMdMqVKJR48AhGU7NgPJ5SIlO/+seL2VSO+dtv7aEOEIaT6BA==}
+    engines: {node: '>= 10.*'}
+    dependencies:
+      '@babel/core': 7.17.2
+      '@babel/preset-env': 7.16.11_@babel+core@7.17.2
+      '@babel/traverse': 7.17.0
+      '@babel/types': 7.17.0
+      '@embroider/shared-internals': 1.2.0
+      babel-core: 6.26.3
+      babel-loader: 8.2.3_60b7ed408fec1293d95f86d9ceaa88ca
+      babel-plugin-syntax-dynamic-import: 6.18.0
+      babylon: 6.18.0
+      broccoli-debug: 0.6.5
+      broccoli-node-api: 1.7.0
+      broccoli-plugin: 4.0.7
+      broccoli-source: 3.0.1
+      debug: 3.2.6
+      ember-cli-babel: 7.26.11
+      enhanced-resolve: 4.5.0
+      fs-extra: 6.0.1
+      fs-tree-diff: 2.0.1
+      handlebars: 4.7.7
+      js-string-escape: 1.0.1
+      lodash: 4.17.21
+      mkdirp: 0.5.5
+      resolve-package-path: 3.1.0
+      rimraf: 2.7.1
+      semver: 7.3.4
+      symlink-or-copy: 1.3.1
+      typescript-memoize: 1.1.0
+      walk-sync: 0.3.4
+      webpack: 4.46.0
     transitivePeerDependencies:
-      - '@babel/core'
+      - supports-color
+      - webpack-cli
+      - webpack-command
     dev: true
 
   /ember-cli-babel-plugin-helpers/1.1.1:
     resolution: {integrity: sha512-sKvOiPNHr5F/60NLd7SFzMpYPte/nnGkq/tMIfXejfKHIhaiIkYFqX8Z9UFTKWLLn+V7NOaby6niNPZUdvKCRw==}
     engines: {node: 6.* || 8.* || >= 10.*}
-    dev: true
-
-  /ember-cli-babel/6.18.0:
-    resolution: {integrity: sha512-7ceC8joNYxY2wES16iIBlbPSxwKDBhYwC8drU3ZEvuPDMwVv1KzxCNu1fvxyFEBWhwaRNTUxSCsEVoTd9nosGA==}
-    engines: {node: ^4.5 || 6.* || >= 7.*}
-    dependencies:
-      amd-name-resolver: 1.2.0
-      babel-plugin-debug-macros: 0.2.0
-      babel-plugin-ember-modules-api-polyfill: 2.13.4
-      babel-plugin-transform-es2015-modules-amd: 6.24.1
-      babel-polyfill: 6.26.0
-      babel-preset-env: 1.7.0
-      broccoli-babel-transpiler: 6.5.0
-      broccoli-debug: 0.6.5
-      broccoli-funnel: 2.0.2
-      broccoli-source: 1.1.0
-      clone: 2.1.2
-      ember-cli-version-checker: 2.1.2
-      semver: 5.7.1
-    transitivePeerDependencies:
-      - '@babel/core'
     dev: true
 
   /ember-cli-babel/7.26.11:
@@ -4943,21 +6224,6 @@ packages:
 
   /ember-cli-get-component-path-option/1.0.0:
     resolution: {integrity: sha1-DXtZVVni+QUKvtgE8djv8bCLx3E=}
-    dev: true
-
-  /ember-cli-htmlbars-inline-precompile/2.1.0_ember-cli-babel@7.26.11:
-    resolution: {integrity: sha512-BylIHduwQkncPhnj0ZyorBuljXbTzLgRo6kuHf1W+IHFxThFl2xG+r87BVwsqx4Mn9MTgW9SE0XWjwBJcSWd6Q==}
-    engines: {node: 6.* || 8.* || >= 10.*}
-    deprecated: Use ember-cli-htmlbars instead.
-    peerDependencies:
-      ember-cli-babel: ^6.7.1 || ^7.0.0
-    dependencies:
-      babel-plugin-htmlbars-inline-precompile: 1.0.0
-      ember-cli-babel: 7.26.11
-      ember-cli-version-checker: 2.1.2
-      hash-for-dep: 1.5.1
-      heimdalljs-logger: 0.1.10
-      silent-error: 1.1.1
     dev: true
 
   /ember-cli-htmlbars-inline-precompile/3.0.2_ember-cli-babel@7.26.11:
@@ -5040,13 +6306,13 @@ packages:
     resolution: {integrity: sha1-ObZ3/CgF9VFzc1N2/O8njqpEUqE=}
     dev: true
 
-  /ember-cli-test-loader/2.2.0:
-    resolution: {integrity: sha512-mlSXX9SciIRwGkFTX6XGyJYp4ry6oCFZRxh5jJ7VH8UXLTNx2ZACtDTwaWtNhYrWXgKyiDUvmD8enD56aePWRA==}
-    engines: {node: '>= 4.0'}
+  /ember-cli-test-loader/3.0.0:
+    resolution: {integrity: sha512-wfFRBrfO9gaKScYcdQxTfklx9yp1lWK6zv1rZRpkas9z2SHyJojF7NOQRWQgSB3ypm7vfpiF8VsFFVVr7VBzAQ==}
+    engines: {node: 10.* || >= 12}
     dependencies:
-      ember-cli-babel: 6.18.0
+      ember-cli-babel: 7.26.11
     transitivePeerDependencies:
-      - '@babel/core'
+      - supports-color
     dev: true
 
   /ember-cli-typescript/2.0.2:
@@ -5213,6 +6479,31 @@ packages:
       - utf-8-validate
     dev: true
 
+  /ember-compatibility-helpers/1.2.6:
+    resolution: {integrity: sha512-2UBUa5SAuPg8/kRVaiOfTwlXdeVweal1zdNPibwItrhR0IvPrXpaqwJDlEZnWKEoB+h33V0JIfiWleSG6hGkkA==}
+    engines: {node: 10.* || >= 12.*}
+    dependencies:
+      babel-plugin-debug-macros: 0.2.0
+      ember-cli-version-checker: 5.1.2
+      find-up: 5.0.0
+      fs-extra: 9.1.0
+      semver: 5.7.1
+    transitivePeerDependencies:
+      - '@babel/core'
+    dev: true
+
+  /ember-destroyable-polyfill/2.0.3:
+    resolution: {integrity: sha512-TovtNqCumzyAiW0/OisSkkVK93xnVF4NRU6+FN0ubpfwEOpRrmM2RqDwXI6YAChCgSHON1cz0DfQStpA1Gjuuw==}
+    engines: {node: 10.* || >= 12}
+    dependencies:
+      ember-cli-babel: 7.26.11
+      ember-cli-version-checker: 5.1.2
+      ember-compatibility-helpers: 1.2.6
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
+    dev: true
+
   /ember-disable-prototype-extensions/1.1.3:
     resolution: {integrity: sha1-GWkTUhdlS14nj5/i2dTkm1cgMp4=}
     engines: {node: '>= 0.10.0'}
@@ -5241,20 +6532,28 @@ packages:
       - supports-color
     dev: true
 
-  /ember-mocha/0.16.2:
-    resolution: {integrity: sha512-K3ZoOgMSGQJB9EwbYFij2v+fsNEzneOr2NLMGeI+6xaPpRYzcAS6Y5wBzsqvayI+7f5c1oyuca7jSg8vX+NE+w==}
-    engines: {node: 8.* || >= 10.*}
+  /ember-qunit/5.1.5_71cf3139f132abb8fb8e124dd974b045:
+    resolution: {integrity: sha512-2cFA4oMygh43RtVcMaBrr086Tpdhgbn3fVZ2awLkzF/rnSN0D0PSRpd7hAD7OdBPerC/ZYRwzVyGXLoW/Zes4A==}
+    engines: {node: 10.* || 12.* || >= 14.*}
+    peerDependencies:
+      '@ember/test-helpers': ^2.4.0
+      qunit: ^2.13.0
     dependencies:
-      '@ember/test-helpers': 1.7.1
-      broccoli-funnel: 2.0.2
+      '@ember/test-helpers': 2.6.0
+      broccoli-funnel: 3.0.8
       broccoli-merge-trees: 3.0.2
       common-tags: 1.8.0
+      ember-auto-import: 1.12.1
       ember-cli-babel: 7.26.11
-      ember-cli-test-loader: 2.2.0
-      mocha: 2.5.3
+      ember-cli-test-loader: 3.0.0
+      qunit: 2.17.2
+      resolve-package-path: 3.1.0
+      silent-error: 1.1.1
+      validate-peer-dependencies: 1.2.0
     transitivePeerDependencies:
-      - '@babel/core'
       - supports-color
+      - webpack-cli
+      - webpack-command
     dev: true
 
   /ember-resolver/8.0.3:
@@ -5325,19 +6624,10 @@ packages:
       inflection: 1.13.2
       jquery: 3.6.0
       resolve: 1.20.0
-      semver: 7.3.4
+      semver: 7.3.5
       silent-error: 1.1.1
     transitivePeerDependencies:
       - '@babel/core'
-      - supports-color
-    dev: true
-
-  /ember-test-waiters/1.1.1:
-    resolution: {integrity: sha512-ra71ZWTGBGLeDPa308aeAg9+/nYxv2fk4OEzmXdhvbSa5Dtbei94sr5pbLXx2IiK3Re2gDAvDzxg9PVhLy9fig==}
-    engines: {node: 6.* || 8.* || >= 10.*}
-    dependencies:
-      ember-cli-babel: 7.26.11
-    transitivePeerDependencies:
       - supports-color
     dev: true
 
@@ -5384,6 +6674,11 @@ packages:
 
   /emoji-regex/8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+    dev: true
+
+  /emojis-list/3.0.0:
+    resolution: {integrity: sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==}
+    engines: {node: '>= 4'}
     dev: true
 
   /encodeurl/1.0.2:
@@ -5449,6 +6744,15 @@ packages:
       - utf-8-validate
     dev: true
 
+  /enhanced-resolve/4.5.0:
+    resolution: {integrity: sha512-Nv9m36S/vxpsI+Hc4/ZGRs0n9mXqSWGGq49zxb/cJfPAQMbUtttJAlNPS4AQzaBdw/pKskw5bMbekT/Y7W/Wlg==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      graceful-fs: 4.2.9
+      memory-fs: 0.5.0
+      tapable: 1.1.3
+    dev: true
+
   /enquirer/2.3.5:
     resolution: {integrity: sha512-BNT1C08P9XD0vNg3J475yIUG+mVdp9T6towYFHUv897X0KoHBjB1shyrNmhmtHWKP17iSWgo7Gqh7BBuzLZMSA==}
     engines: {node: '>=8.6'}
@@ -5475,6 +6779,13 @@ packages:
   /errlop/2.2.0:
     resolution: {integrity: sha512-e64Qj9+4aZzjzzFpZC7p5kmm/ccCrbLhAJplhsDXQFs87XTsXwOpH4s1Io2s90Tau/8r2j9f4l/thhDevRjzxw==}
     engines: {node: '>=0.8'}
+    dev: true
+
+  /errno/0.1.8:
+    resolution: {integrity: sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==}
+    hasBin: true
+    dependencies:
+      prr: 1.0.1
     dev: true
 
   /error-ex/1.3.2:
@@ -5552,11 +6863,6 @@ packages:
     resolution: {integrity: sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=}
     dev: true
 
-  /escape-string-regexp/1.0.2:
-    resolution: {integrity: sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE=}
-    engines: {node: '>=0.8.0'}
-    dev: true
-
   /escape-string-regexp/1.0.5:
     resolution: {integrity: sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=}
     engines: {node: '>=0.8.0'}
@@ -5596,6 +6902,14 @@ packages:
       fs-extra: 2.1.2
       pify: 2.3.0
       supports-color: 3.2.3
+    dev: true
+
+  /eslint-scope/4.0.3:
+    resolution: {integrity: sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==}
+    engines: {node: '>=4.0.0'}
+    dependencies:
+      esrecurse: 4.3.0
+      estraverse: 4.2.0
     dev: true
 
   /eslint-scope/5.1.1:
@@ -5757,6 +7071,18 @@ packages:
 
   /events-to-array/1.1.2:
     resolution: {integrity: sha1-LUH1Y+H+QA7Uli/hpNXGp1Od9/Y=}
+    dev: true
+
+  /events/3.3.0:
+    resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
+    engines: {node: '>=0.8.x'}
+    dev: true
+
+  /evp_bytestokey/1.0.3:
+    resolution: {integrity: sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==}
+    dependencies:
+      md5.js: 1.3.5
+      safe-buffer: 5.2.1
     dev: true
 
   /exec-sh/0.3.6:
@@ -6046,6 +7372,11 @@ packages:
       flat-cache: 3.0.4
     dev: true
 
+  /file-uri-to-path/1.0.0:
+    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
+    dev: true
+    optional: true
+
   /filename-regex/2.0.1:
     resolution: {integrity: sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=}
     engines: {node: '>=0.10.0'}
@@ -6118,6 +7449,24 @@ packages:
       path-exists: 3.0.0
     dev: true
 
+  /find-cache-dir/2.1.0:
+    resolution: {integrity: sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==}
+    engines: {node: '>=6'}
+    dependencies:
+      commondir: 1.0.1
+      make-dir: 2.1.0
+      pkg-dir: 3.0.0
+    dev: true
+
+  /find-cache-dir/3.3.2:
+    resolution: {integrity: sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==}
+    engines: {node: '>=8'}
+    dependencies:
+      commondir: 1.0.1
+      make-dir: 3.1.0
+      pkg-dir: 4.2.0
+    dev: true
+
   /find-index/1.1.0:
     resolution: {integrity: sha1-UwB8ec0wBA1oFteUWOiDfVxXBe8=}
     dev: true
@@ -6162,7 +7511,7 @@ packages:
   /find-yarn-workspace-root/2.0.0:
     resolution: {integrity: sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==}
     dependencies:
-      micromatch: 4.0.4
+      micromatch: 4.0.2
     dev: true
 
   /findup-sync/4.0.0:
@@ -6236,6 +7585,13 @@ packages:
     resolution: {integrity: sha512-tW+UkmtNg/jv9CSofAKvgVcO7c2URjhTdW1ZTkcAritblu8tajiYy7YisnIflEwtKssCtOxpnBRoCB7iap0/TA==}
     dev: true
 
+  /flush-write-stream/1.1.1:
+    resolution: {integrity: sha512-3Z4XhFZ3992uIq0XOqb9AreonueSYphE6oYbpt5+3u06JWklbsPkNv3ZKkP9Bz/r+1MWCaMoSQ28P85+1Yc77w==}
+    dependencies:
+      inherits: 2.0.4
+      readable-stream: 2.3.6
+    dev: true
+
   /follow-redirects/1.7.0:
     resolution: {integrity: sha512-m/pZQy4Gj287eNy94nivy5wchN3Kp+Q5WgUPNy5lJSZ3sgkVKSYV/ZChMAQVIgx1SqfZ2zBZtPA2YlXIWxxJOQ==}
     engines: {node: '>=4.0'}
@@ -6281,6 +7637,13 @@ packages:
     engines: {node: '>= 0.6'}
     dev: true
 
+  /from2/2.3.0:
+    resolution: {integrity: sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=}
+    dependencies:
+      inherits: 2.0.4
+      readable-stream: 2.3.6
+    dev: true
+
   /fs-extra/0.24.0:
     resolution: {integrity: sha1-1OQ0KpZnXLeEZjOmCZJJMytTmVI=}
     dependencies:
@@ -6312,7 +7675,7 @@ packages:
     dependencies:
       graceful-fs: 4.2.9
       jsonfile: 4.0.0
-      universalify: 0.1.2
+      universalify: 0.1.1
     dev: true
 
   /fs-extra/5.0.0:
@@ -6323,13 +7686,21 @@ packages:
       universalify: 0.1.2
     dev: true
 
+  /fs-extra/6.0.1:
+    resolution: {integrity: sha512-GnyIkKhhzXZUWFCaJzvyDLEEgDkPfb4/TPvJCJVuS8MWZgoSsErf++QpiAlDnKFcqhRlm+tIOcencCjyJE6ZCA==}
+    dependencies:
+      graceful-fs: 4.2.9
+      jsonfile: 4.0.0
+      universalify: 0.1.1
+    dev: true
+
   /fs-extra/7.0.1:
     resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
     engines: {node: '>=6 <7 || >=8'}
     dependencies:
       graceful-fs: 4.2.9
       jsonfile: 4.0.0
-      universalify: 0.1.2
+      universalify: 0.1.1
     dev: true
 
   /fs-extra/8.1.0:
@@ -6338,7 +7709,7 @@ packages:
     dependencies:
       graceful-fs: 4.2.9
       jsonfile: 4.0.0
-      universalify: 0.1.2
+      universalify: 0.1.1
     dev: true
 
   /fs-extra/9.1.0:
@@ -6346,7 +7717,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       at-least-node: 1.0.0
-      graceful-fs: 4.2.9
+      graceful-fs: 4.2.4
       jsonfile: 6.0.1
       universalify: 2.0.0
     dev: true
@@ -6411,6 +7782,18 @@ packages:
   /fs.realpath/1.0.0:
     resolution: {integrity: sha1-FQStJSMVjKpA20onh8sBQRmU6k8=}
     dev: true
+
+  /fsevents/1.2.13:
+    resolution: {integrity: sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==}
+    engines: {node: '>= 4.0'}
+    os: [darwin]
+    deprecated: fsevents 1 will break on node v14+ and could be using insecure binaries. Upgrade to fsevents 2.
+    requiresBuild: true
+    dependencies:
+      bindings: 1.5.0
+      nan: 2.15.0
+    dev: true
+    optional: true
 
   /fsevents/2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
@@ -6512,18 +7895,19 @@ packages:
       is-glob: 2.0.1
     dev: true
 
+  /glob-parent/3.1.0:
+    resolution: {integrity: sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=}
+    dependencies:
+      is-glob: 3.1.0
+      path-dirname: 1.0.2
+    dev: true
+    optional: true
+
   /glob-parent/5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
     dependencies:
       is-glob: 4.0.1
-    dev: true
-
-  /glob/3.2.11:
-    resolution: {integrity: sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=}
-    dependencies:
-      inherits: 2.0.4
-      minimatch: 0.3.0
     dev: true
 
   /glob/5.0.15:
@@ -6595,6 +7979,10 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
+  /globalyzer/0.1.0:
+    resolution: {integrity: sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q==}
+    dev: true
+
   /globby/10.0.0:
     resolution: {integrity: sha512-3LifW9M4joGZasyYPz2A1U74zbC/45fvpXUvO/9KbSa+VV0aGZarWkfdgKyR9sExNP0t0x0ss/UMJpNpcaTspw==}
     engines: {node: '>=8'}
@@ -6607,6 +7995,10 @@ packages:
       ignore: 5.1.4
       merge2: 1.3.0
       slash: 3.0.0
+    dev: true
+
+  /globrex/0.1.2:
+    resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
     dev: true
 
   /got/9.6.0:
@@ -6626,16 +8018,16 @@ packages:
       url-parse-lax: 3.0.0
     dev: true
 
+  /graceful-fs/4.2.4:
+    resolution: {integrity: sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==}
+    dev: true
+
   /graceful-fs/4.2.9:
     resolution: {integrity: sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==}
     dev: true
 
   /graceful-readlink/1.0.1:
     resolution: {integrity: sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=}
-    dev: true
-
-  /growl/1.9.2:
-    resolution: {integrity: sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=}
     dev: true
 
   /growly/1.3.0:
@@ -6741,6 +8133,15 @@ packages:
       function-bind: 1.1.1
     dev: true
 
+  /hash-base/3.1.0:
+    resolution: {integrity: sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==}
+    engines: {node: '>=4'}
+    dependencies:
+      inherits: 2.0.4
+      readable-stream: 3.6.0
+      safe-buffer: 5.2.1
+    dev: true
+
   /hash-for-dep/1.5.1:
     resolution: {integrity: sha512-/dQ/A2cl7FBPI2pO0CANkvuuVi/IFS5oTyJ0PsOb6jW6WbVW1js5qJXMJTNbWHXBIPdFTWFbabjB+mE0d+gelw==}
     dependencies:
@@ -6760,6 +8161,13 @@ packages:
       sort-keys: 4.0.0
       type-fest: 0.8.1
     dev: false
+
+  /hash.js/1.1.7:
+    resolution: {integrity: sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==}
+    dependencies:
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
+    dev: true
 
   /heimdalljs-fs-monitor/1.1.1:
     resolution: {integrity: sha512-BHB8oOXLRlrIaON0MqJSEjGVPDyqt2Y6gu+w2PaEZjrCxeVtZG7etEZp7M4ZQ80HNvnr66KIQ2lot2qdeG8HgQ==}
@@ -6793,6 +8201,14 @@ packages:
     resolution: {integrity: sha512-a5bFyofd/BHCX52/8i8uJkjr9DYwXIPnM/plwI6W7ezItLGqzt7X2G2nXuYSfsIJdkwwj/g9DG1LkcGJI/dDoA==}
     deprecated: Support has ended for 9.x series. Upgrade to @latest
     requiresBuild: true
+    dev: true
+
+  /hmac-drbg/1.0.1:
+    resolution: {integrity: sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=}
+    dependencies:
+      hash.js: 1.1.7
+      minimalistic-assert: 1.0.1
+      minimalistic-crypto-utils: 1.0.1
     dev: true
 
   /home-or-tmp/2.0.0:
@@ -6898,6 +8314,10 @@ packages:
       requires-port: 1.0.0
     dev: true
 
+  /https-browserify/1.0.0:
+    resolution: {integrity: sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=}
+    dev: true
+
   /https-proxy-agent/4.0.0:
     resolution: {integrity: sha512-zoDhWrkR3of1l9QAL8/scJZyLu8j/gBkcwcaQOZh7Gyh/+uJQzGVETdgT30akuwkpL8HTRfssqI3BZuV18teDg==}
     engines: {node: '>= 6.0.0'}
@@ -6943,6 +8363,10 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       safer-buffer: 2.1.2
+    dev: true
+
+  /ieee754/1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
     dev: true
 
   /iferr/0.1.5:
@@ -7004,6 +8428,10 @@ packages:
     dependencies:
       once: 1.4.0
       wrappy: 1.0.2
+    dev: true
+
+  /inherits/2.0.1:
+    resolution: {integrity: sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=}
     dev: true
 
   /inherits/2.0.3:
@@ -7099,6 +8527,22 @@ packages:
   /is-arrayish/0.2.1:
     resolution: {integrity: sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=}
     dev: true
+
+  /is-binary-path/1.0.1:
+    resolution: {integrity: sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      binary-extensions: 1.13.1
+    dev: true
+    optional: true
+
+  /is-binary-path/2.1.0:
+    resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
+    engines: {node: '>=8'}
+    dependencies:
+      binary-extensions: 2.2.0
+    dev: true
+    optional: true
 
   /is-buffer/1.1.6:
     resolution: {integrity: sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==}
@@ -7217,6 +8661,14 @@ packages:
       is-extglob: 1.0.0
     dev: true
 
+  /is-glob/3.1.0:
+    resolution: {integrity: sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      is-extglob: 2.1.1
+    dev: true
+    optional: true
+
   /is-glob/4.0.1:
     resolution: {integrity: sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==}
     engines: {node: '>=0.10.0'}
@@ -7311,6 +8763,11 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
+  /is-wsl/1.1.0:
+    resolution: {integrity: sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=}
+    engines: {node: '>=4'}
+    dev: true
+
   /isarray/0.0.1:
     resolution: {integrity: sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=}
     dev: true
@@ -7372,7 +8829,7 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       istanbul-lib-coverage: 3.0.0
-      make-dir: 3.0.0
+      make-dir: 3.1.0
       supports-color: 7.1.0
     dev: true
 
@@ -7381,7 +8838,7 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       debug: 4.3.3
-      istanbul-lib-coverage: 3.2.0
+      istanbul-lib-coverage: 3.0.0
       source-map: 0.6.1
     transitivePeerDependencies:
       - supports-color
@@ -7411,15 +8868,6 @@ packages:
       binaryextensions: 2.3.0
       editions: 2.3.1
       textextensions: 2.6.0
-    dev: true
-
-  /jade/0.26.3:
-    resolution: {integrity: sha1-jxDXl32NefL2/4YqgbBRPMslaGw=}
-    deprecated: Jade has been renamed to pug, please install the latest version of pug instead of jade
-    hasBin: true
-    dependencies:
-      commander: 0.6.1
-      mkdirp: 0.3.0
     dev: true
 
   /jest-changed-files/27.5.1:
@@ -7598,7 +9046,7 @@ packages:
       '@jest/types': 27.5.1
       '@types/graceful-fs': 4.1.3
       '@types/node': 11.13.8
-      anymatch: 3.1.1
+      anymatch: 3.1.2
       fb-watchman: 2.0.1
       graceful-fs: 4.2.9
       jest-regex-util: 27.5.1
@@ -7744,7 +9192,7 @@ packages:
       jest-runtime: 27.5.1
       jest-util: 27.5.1
       jest-worker: 27.5.1
-      source-map-support: 0.5.9
+      source-map-support: 0.5.21
       throat: 6.0.1
     transitivePeerDependencies:
       - bufferutil
@@ -7816,7 +9264,7 @@ packages:
       jest-util: 27.5.1
       natural-compare: 1.4.0
       pretty-format: 27.5.1
-      semver: 7.3.4
+      semver: 7.3.5
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -7890,6 +9338,11 @@ packages:
 
   /jquery/3.6.0:
     resolution: {integrity: sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==}
+    dev: true
+
+  /js-string-escape/1.0.1:
+    resolution: {integrity: sha1-4mJbrbwNZ8dTPp7cEGjFh65BN+8=}
+    engines: {node: '>= 0.8'}
     dev: true
 
   /js-tokens/3.0.2:
@@ -7975,6 +9428,10 @@ packages:
     resolution: {integrity: sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=}
     dev: true
 
+  /json-parse-better-errors/1.0.2:
+    resolution: {integrity: sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==}
+    dev: true
+
   /json-parse-even-better-errors/2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
     dev: true
@@ -8000,6 +9457,13 @@ packages:
   /json5/0.5.1:
     resolution: {integrity: sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=}
     hasBin: true
+    dev: true
+
+  /json5/1.0.1:
+    resolution: {integrity: sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==}
+    hasBin: true
+    dependencies:
+      minimist: 1.2.5
     dev: true
 
   /json5/2.1.2:
@@ -8139,6 +9603,20 @@ packages:
 
   /livereload-js/3.3.1:
     resolution: {integrity: sha512-CBu1gTEfzVhlOK1WASKAAJ9Qx1fHECTq0SUB67sfxwQssopTyvzqTlgl+c0h9pZ6V+Fzd2rc510ppuNusg9teQ==}
+    dev: true
+
+  /loader-runner/2.4.0:
+    resolution: {integrity: sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw==}
+    engines: {node: '>=4.3.0 <5.0.0 || >=5.10'}
+    dev: true
+
+  /loader-utils/1.4.0:
+    resolution: {integrity: sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==}
+    engines: {node: '>=4.0.0'}
+    dependencies:
+      big.js: 5.2.2
+      emojis-list: 3.0.0
+      json5: 1.0.1
     dev: true
 
   /loader.js/4.7.0:
@@ -8526,10 +10004,6 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /lru-cache/2.7.3:
-    resolution: {integrity: sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=}
-    dev: true
-
   /lru-cache/4.1.1:
     resolution: {integrity: sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==}
     dependencies:
@@ -8556,8 +10030,23 @@ packages:
       vlq: 0.2.3
     dev: true
 
+  /make-dir/2.1.0:
+    resolution: {integrity: sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==}
+    engines: {node: '>=6'}
+    dependencies:
+      pify: 4.0.1
+      semver: 5.7.1
+    dev: true
+
   /make-dir/3.0.0:
     resolution: {integrity: sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==}
+    engines: {node: '>=8'}
+    dependencies:
+      semver: 6.3.0
+    dev: true
+
+  /make-dir/3.1.0:
+    resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
     engines: {node: '>=8'}
     dependencies:
       semver: 6.3.0
@@ -8661,6 +10150,14 @@ packages:
     resolution: {integrity: sha1-givM1l4RfFFPqxdrJZRdVBAKA8M=}
     dev: true
 
+  /md5.js/1.3.5:
+    resolution: {integrity: sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==}
+    dependencies:
+      hash-base: 3.1.0
+      inherits: 2.0.4
+      safe-buffer: 5.2.1
+    dev: true
+
   /mdurl/1.0.1:
     resolution: {integrity: sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=}
     dev: true
@@ -8668,6 +10165,21 @@ packages:
   /media-typer/0.3.0:
     resolution: {integrity: sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=}
     engines: {node: '>= 0.6'}
+    dev: true
+
+  /memory-fs/0.4.1:
+    resolution: {integrity: sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=}
+    dependencies:
+      errno: 0.1.8
+      readable-stream: 2.3.6
+    dev: true
+
+  /memory-fs/0.5.0:
+    resolution: {integrity: sha512-jA0rdU5KoQMC0e6ppoNRtpp6vjFq6+NY7r8hywnC7V+1Xj/MtHwGIbB1QaK/dunyjWteJzmkpd7ooeWg10T7GA==}
+    engines: {node: '>=4.3.0 <5.0.0 || >=5.10'}
+    dependencies:
+      errno: 0.1.8
+      readable-stream: 2.3.6
     dev: true
 
   /memory-streams/0.1.3:
@@ -8750,12 +10262,28 @@ packages:
       to-regex: 3.0.2
     dev: true
 
+  /micromatch/4.0.2:
+    resolution: {integrity: sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==}
+    engines: {node: '>=8'}
+    dependencies:
+      braces: 3.0.2
+      picomatch: 2.3.1
+    dev: true
+
   /micromatch/4.0.4:
     resolution: {integrity: sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==}
     engines: {node: '>=8.6'}
     dependencies:
       braces: 3.0.2
       picomatch: 2.3.1
+    dev: true
+
+  /miller-rabin/4.0.1:
+    resolution: {integrity: sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==}
+    hasBin: true
+    dependencies:
+      bn.js: 4.12.0
+      brorand: 1.1.0
     dev: true
 
   /mime-db/1.45.0:
@@ -8791,22 +10319,18 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
-  /minimatch/0.3.0:
-    resolution: {integrity: sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=}
-    deprecated: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
-    dependencies:
-      lru-cache: 2.7.3
-      sigmund: 1.0.1
+  /minimalistic-assert/1.0.1:
+    resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
+    dev: true
+
+  /minimalistic-crypto-utils/1.0.1:
+    resolution: {integrity: sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=}
     dev: true
 
   /minimatch/3.0.4:
     resolution: {integrity: sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==}
     dependencies:
       brace-expansion: 1.1.8
-    dev: true
-
-  /minimist/0.0.8:
-    resolution: {integrity: sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=}
     dev: true
 
   /minimist/0.2.1:
@@ -8860,7 +10384,7 @@ packages:
   /minipass/2.3.5:
     resolution: {integrity: sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==}
     dependencies:
-      safe-buffer: 5.1.2
+      safe-buffer: 5.2.1
       yallist: 3.0.3
     dev: true
 
@@ -8879,25 +10403,28 @@ packages:
       yallist: 4.0.0
     dev: true
 
+  /mississippi/3.0.0:
+    resolution: {integrity: sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==}
+    engines: {node: '>=4.0.0'}
+    dependencies:
+      concat-stream: 1.6.2
+      duplexify: 3.7.1
+      end-of-stream: 1.4.1
+      flush-write-stream: 1.1.1
+      from2: 2.3.0
+      parallel-transform: 1.2.0
+      pump: 3.0.0
+      pumpify: 1.5.1
+      stream-each: 1.2.3
+      through2: 2.0.5
+    dev: true
+
   /mixin-deep/1.3.2:
     resolution: {integrity: sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==}
     engines: {node: '>=0.10.0'}
     dependencies:
       for-in: 1.0.2
       is-extendable: 1.0.1
-    dev: true
-
-  /mkdirp/0.3.0:
-    resolution: {integrity: sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=}
-    deprecated: Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)
-    dev: true
-
-  /mkdirp/0.5.1:
-    resolution: {integrity: sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=}
-    deprecated: Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)
-    hasBin: true
-    dependencies:
-      minimist: 0.0.8
     dev: true
 
   /mkdirp/0.5.5:
@@ -8916,23 +10443,6 @@ packages:
   /mktemp/0.4.0:
     resolution: {integrity: sha1-bQUVYRyKjITkhKogABKbmOmB/ws=}
     engines: {node: '>0.9'}
-    dev: true
-
-  /mocha/2.5.3:
-    resolution: {integrity: sha1-FhvlvetJZ3HrmzV0UFC2IrWu/Fg=}
-    engines: {node: '>= 0.8.x'}
-    hasBin: true
-    dependencies:
-      commander: 2.3.0
-      debug: 2.2.0
-      diff: 1.4.0
-      escape-string-regexp: 1.0.2
-      glob: 3.2.11
-      growl: 1.9.2
-      jade: 0.26.3
-      mkdirp: 0.5.1
-      supports-color: 1.2.0
-      to-iso-string: 0.0.2
     dev: true
 
   /morgan/1.10.0:
@@ -8959,10 +10469,6 @@ packages:
       mkdirp: 0.5.5
       rimraf: 2.7.1
       run-queue: 1.0.3
-    dev: true
-
-  /ms/0.7.1:
-    resolution: {integrity: sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=}
     dev: true
 
   /ms/2.0.0:
@@ -9002,6 +10508,11 @@ packages:
       object-assign: 4.1.1
       thenify-all: 1.6.0
     dev: true
+
+  /nan/2.15.0:
+    resolution: {integrity: sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==}
+    dev: true
+    optional: true
 
   /nanomatch/1.2.13:
     resolution: {integrity: sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==}
@@ -9053,6 +10564,34 @@ packages:
     resolution: {integrity: sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=}
     dev: true
 
+  /node-libs-browser/2.2.1:
+    resolution: {integrity: sha512-h/zcD8H9kaDZ9ALUWwlBUDo6TKF8a7qBSCSEGfjTVIYeqsioSKaAX+BN7NgiMGp6iSIXZ3PxgCu8KS3b71YK5Q==}
+    dependencies:
+      assert: 1.5.0
+      browserify-zlib: 0.2.0
+      buffer: 4.9.2
+      console-browserify: 1.2.0
+      constants-browserify: 1.0.0
+      crypto-browserify: 3.12.0
+      domain-browser: 1.2.0
+      events: 3.3.0
+      https-browserify: 1.0.0
+      os-browserify: 0.3.0
+      path-browserify: 0.0.1
+      process: 0.11.10
+      punycode: 1.4.1
+      querystring-es3: 0.2.1
+      readable-stream: 2.3.6
+      stream-browserify: 2.0.2
+      stream-http: 2.8.3
+      string_decoder: 1.2.0
+      timers-browserify: 2.0.12
+      tty-browserify: 0.0.0
+      url: 0.11.0
+      util: 0.11.1
+      vm-browserify: 1.1.2
+    dev: true
+
   /node-modules-path/1.0.1:
     resolution: {integrity: sha1-QAlrCM560OoUaAhjr0ScfHWl0cg=}
     dev: true
@@ -9068,6 +10607,11 @@ packages:
 
   /node-releases/2.0.2:
     resolution: {integrity: sha512-XxYDdcQ6eKqp/YjI+tb2C5WM2LgjnZrfYg4vgQt49EK268b6gYCHsBLrK2qvJo4FmCtqmKezb0WZFK4fkrZNsg==}
+    dev: true
+
+  /node-watch/0.7.2:
+    resolution: {integrity: sha512-g53VjSARRv1JdST0LZRIg8RiuLr1TaBbVPsVvxh0/0Ymvi0xYUjDuoqQQAWtHJQUXhiShowPT/aXKNeHBcyQsw==}
+    engines: {node: '>=6'}
     dev: true
 
   /nopt/3.0.6:
@@ -9263,6 +10807,10 @@ packages:
       wcwidth: 1.0.1
     dev: true
 
+  /os-browserify/0.3.0:
+    resolution: {integrity: sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=}
+    dev: true
+
   /os-homedir/1.0.2:
     resolution: {integrity: sha1-/7xJiDNuDoM94MFox+8VISGqf7M=}
     engines: {node: '>=0.10.0'}
@@ -9371,11 +10919,33 @@ packages:
       semver: 6.3.0
     dev: true
 
+  /pako/1.0.11:
+    resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
+    dev: true
+
+  /parallel-transform/1.2.0:
+    resolution: {integrity: sha512-P2vSmIu38uIlvdcU7fDkyrxj33gTUy/ABO5ZUbGowxNCopBq/OoD42bP4UmMrJoPyk4Uqf0mu3mtWBhHCZD8yg==}
+    dependencies:
+      cyclist: 1.0.1
+      inherits: 2.0.4
+      readable-stream: 2.3.6
+    dev: true
+
   /parent-module/1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
     dependencies:
       callsites: 3.1.0
+    dev: true
+
+  /parse-asn1/5.1.6:
+    resolution: {integrity: sha512-RnZRo1EPU6JBnra2vGHj0yhp6ebyjBZpmUCLHWiFhxlzvBCCpAuZ7elsBp1PVAbQN0/04VD/19rfzlBSwLstMw==}
+    dependencies:
+      asn1.js: 5.4.1
+      browserify-aes: 1.2.0
+      evp_bytestokey: 1.0.3
+      pbkdf2: 3.1.2
+      safe-buffer: 5.2.1
     dev: true
 
   /parse-glob/3.0.4:
@@ -9435,6 +11005,15 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
+  /path-browserify/0.0.1:
+    resolution: {integrity: sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ==}
+    dev: true
+
+  /path-dirname/1.0.2:
+    resolution: {integrity: sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=}
+    dev: true
+    optional: true
+
   /path-exists/3.0.0:
     resolution: {integrity: sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=}
     engines: {node: '>=4'}
@@ -9493,6 +11072,17 @@ packages:
     resolution: {integrity: sha1-uULm1L3mUwBe9rcTYd74cn0GReA=}
     dev: true
 
+  /pbkdf2/3.1.2:
+    resolution: {integrity: sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA==}
+    engines: {node: '>=0.12'}
+    dependencies:
+      create-hash: 1.2.0
+      create-hmac: 1.1.7
+      ripemd160: 2.0.2
+      safe-buffer: 5.2.1
+      sha.js: 2.4.11
+    dev: true
+
   /picocolors/1.0.0:
     resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
     dev: true
@@ -9505,6 +11095,11 @@ packages:
   /pify/2.3.0:
     resolution: {integrity: sha1-7RQaasBDqEnqWISY59yosVMw6Qw=}
     engines: {node: '>=0.10.0'}
+    dev: true
+
+  /pify/4.0.1:
+    resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
+    engines: {node: '>=6'}
     dev: true
 
   /pinkie-promise/2.0.1:
@@ -9522,6 +11117,13 @@ packages:
   /pirates/4.0.5:
     resolution: {integrity: sha512-8V9+HQPupnaXMA23c5hvl69zXvTwTzyAYasnkb0Tts4XvO4CliqONMOnvlq26rkhLC3nWDFBJf73LU1e1VZLaQ==}
     engines: {node: '>= 6'}
+    dev: true
+
+  /pkg-dir/3.0.0:
+    resolution: {integrity: sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==}
+    engines: {node: '>=6'}
+    dependencies:
+      find-up: 3.0.0
     dev: true
 
   /pkg-dir/4.2.0:
@@ -9608,6 +11210,11 @@ packages:
       node-modules-path: 1.0.1
     dev: true
 
+  /process/0.11.10:
+    resolution: {integrity: sha1-czIwDoQBYb2j5podHZGn1LwW8YI=}
+    engines: {node: '>= 0.6.0'}
+    dev: true
+
   /progress/2.0.0:
     resolution: {integrity: sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=}
     engines: {node: '>=0.4.0'}
@@ -9657,6 +11264,10 @@ packages:
       ipaddr.js: 1.9.1
     dev: true
 
+  /prr/1.0.1:
+    resolution: {integrity: sha1-0/wRS6BplaRexok/SEzrHXj19HY=}
+    dev: true
+
   /pseudomap/1.0.2:
     resolution: {integrity: sha1-8FKijacOYYkX7wqKw0wa5aaChrM=}
     dev: true
@@ -9665,11 +11276,45 @@ packages:
     resolution: {integrity: sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==}
     dev: true
 
+  /public-encrypt/4.0.3:
+    resolution: {integrity: sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==}
+    dependencies:
+      bn.js: 4.12.0
+      browserify-rsa: 4.1.0
+      create-hash: 1.2.0
+      parse-asn1: 5.1.6
+      randombytes: 2.1.0
+      safe-buffer: 5.2.1
+    dev: true
+
+  /pump/2.0.1:
+    resolution: {integrity: sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==}
+    dependencies:
+      end-of-stream: 1.4.1
+      once: 1.4.0
+    dev: true
+
   /pump/3.0.0:
     resolution: {integrity: sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==}
     dependencies:
       end-of-stream: 1.4.1
       once: 1.4.0
+    dev: true
+
+  /pumpify/1.5.1:
+    resolution: {integrity: sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==}
+    dependencies:
+      duplexify: 3.7.1
+      inherits: 2.0.4
+      pump: 2.0.1
+    dev: true
+
+  /punycode/1.3.2:
+    resolution: {integrity: sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=}
+    dev: true
+
+  /punycode/1.4.1:
+    resolution: {integrity: sha1-wNWmOycYgArY4esPpSachN1BhF4=}
     dev: true
 
   /punycode/2.1.1:
@@ -9682,6 +11327,17 @@ packages:
     engines: {node: '>=0.6'}
     dev: true
 
+  /querystring-es3/0.2.1:
+    resolution: {integrity: sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=}
+    engines: {node: '>=0.4.x'}
+    dev: true
+
+  /querystring/0.2.0:
+    resolution: {integrity: sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=}
+    engines: {node: '>=0.4.x'}
+    deprecated: The querystring API is considered Legacy. new code should use the URLSearchParams API instead.
+    dev: true
+
   /quick-temp/0.1.8:
     resolution: {integrity: sha1-urAqJCq4+w3XWKPJd2sy+aXZRAg=}
     dependencies:
@@ -9690,12 +11346,35 @@ packages:
       underscore.string: 3.3.5
     dev: true
 
+  /qunit/2.17.2:
+    resolution: {integrity: sha512-17isVvuOmALzsPjiV7wFg/6O5vJYXBrQZPwocfQSSh0I/rXvfX7bKMFJ4GMVW3U4P8r2mBeUy8EAngti4QD2Vw==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dependencies:
+      commander: 7.2.0
+      node-watch: 0.7.2
+      tiny-glob: 0.2.9
+    dev: true
+
   /randomatic/1.1.7:
     resolution: {integrity: sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==}
     engines: {node: '>= 0.10.0'}
     dependencies:
       is-number: 3.0.0
       kind-of: 4.0.0
+    dev: true
+
+  /randombytes/2.1.0:
+    resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
+    dependencies:
+      safe-buffer: 5.2.1
+    dev: true
+
+  /randomfill/1.0.4:
+    resolution: {integrity: sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==}
+    dependencies:
+      randombytes: 2.1.0
+      safe-buffer: 5.2.1
     dev: true
 
   /range-parser/1.2.1:
@@ -9765,6 +11444,33 @@ packages:
       util-deprecate: 1.0.2
     dev: true
 
+  /readable-stream/3.6.0:
+    resolution: {integrity: sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==}
+    engines: {node: '>= 6'}
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.2.0
+      util-deprecate: 1.0.2
+    dev: true
+
+  /readdirp/2.2.1:
+    resolution: {integrity: sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==}
+    engines: {node: '>=0.10'}
+    dependencies:
+      graceful-fs: 4.2.9
+      micromatch: 3.1.10
+      readable-stream: 2.3.6
+    dev: true
+    optional: true
+
+  /readdirp/3.6.0:
+    resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
+    engines: {node: '>=8.10.0'}
+    dependencies:
+      picomatch: 2.3.1
+    dev: true
+    optional: true
+
   /recast/0.18.5:
     resolution: {integrity: sha512-sD1WJrpLQAkXGyQZyGzTM75WJvyAd98II5CHdK3IYbt/cZlU0UzCRVU11nUFNXX9fBVEt4E9ajkMjBlUlG+Oog==}
     engines: {node: '>= 4'}
@@ -9794,10 +11500,6 @@ packages:
 
   /regenerate/1.4.2:
     resolution: {integrity: sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==}
-    dev: true
-
-  /regenerator-runtime/0.10.5:
-    resolution: {integrity: sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=}
     dev: true
 
   /regenerator-runtime/0.11.1:
@@ -9999,6 +11701,13 @@ packages:
       resolve: 1.20.0
     dev: true
 
+  /resolve-package-path/4.0.3:
+    resolution: {integrity: sha512-SRpNAPW4kewOaNUt8VPqhJ0UMxawMwzJD8V7m1cJfdSTK9ieZwS6K7Dabsm4bmLFM96Z5Y/UznrpG5kt1im8yA==}
+    engines: {node: '>= 12'}
+    dependencies:
+      path-root: 0.1.1
+    dev: true
+
   /resolve-path/1.4.0:
     resolution: {integrity: sha1-xL2p9e+y/OZSR4c6s2u02DT+Fvc=}
     engines: {node: '>= 0.8'}
@@ -10079,6 +11788,13 @@ packages:
     hasBin: true
     dependencies:
       glob: 7.2.0
+    dev: true
+
+  /ripemd160/2.0.2:
+    resolution: {integrity: sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==}
+    dependencies:
+      hash-base: 3.1.0
+      inherits: 2.0.4
     dev: true
 
   /rollup-plugin-babel/2.7.1:
@@ -10172,6 +11888,10 @@ packages:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
     dev: true
 
+  /safe-buffer/5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+    dev: true
+
   /safe-json-parse/1.0.1:
     resolution: {integrity: sha1-PnZyPjjf3aE8mx0poeB//uSzC1c=}
     dev: true
@@ -10214,7 +11934,7 @@ packages:
       exec-sh: 0.3.6
       execa: 4.1.0
       fb-watchman: 2.0.1
-      micromatch: 4.0.4
+      micromatch: 4.0.2
       minimist: 1.2.5
       walker: 1.0.7
     dev: true
@@ -10224,6 +11944,24 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       xmlchars: 2.2.0
+    dev: true
+
+  /schema-utils/1.0.0:
+    resolution: {integrity: sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==}
+    engines: {node: '>= 4'}
+    dependencies:
+      ajv: 6.12.4
+      ajv-errors: 1.0.1_ajv@6.12.4
+      ajv-keywords: 3.5.2_ajv@6.12.4
+    dev: true
+
+  /schema-utils/2.7.1:
+    resolution: {integrity: sha512-SHiNtMOUGWBQJwzISiVYKu82GiV4QYGePp3odlY1tuKO7gPtphAT5R/py0fA6xtbgLL/RvtJZnU9b8s0F1q0Xg==}
+    engines: {node: '>= 8.9.0'}
+    dependencies:
+      '@types/json-schema': 7.0.9
+      ajv: 6.12.4
+      ajv-keywords: 3.5.2_ajv@6.12.4
     dev: true
 
   /semver/5.7.1:
@@ -10249,6 +11987,14 @@ packages:
       lru-cache: 6.0.0
     dev: true
 
+  /semver/7.3.5:
+    resolution: {integrity: sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dependencies:
+      lru-cache: 6.0.0
+    dev: true
+
   /send/0.17.1:
     resolution: {integrity: sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==}
     engines: {node: '>= 0.8.0'}
@@ -10266,6 +12012,12 @@ packages:
       on-finished: 2.3.0
       range-parser: 1.2.1
       statuses: 1.5.0
+    dev: true
+
+  /serialize-javascript/4.0.0:
+    resolution: {integrity: sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==}
+    dependencies:
+      randombytes: 2.1.0
     dev: true
 
   /serve-static/1.14.1:
@@ -10304,12 +12056,24 @@ packages:
       split-string: 3.1.0
     dev: true
 
+  /setimmediate/1.0.5:
+    resolution: {integrity: sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=}
+    dev: true
+
   /setprototypeof/1.0.3:
     resolution: {integrity: sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=}
     dev: true
 
   /setprototypeof/1.1.1:
     resolution: {integrity: sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==}
+    dev: true
+
+  /sha.js/2.4.11:
+    resolution: {integrity: sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==}
+    hasBin: true
+    dependencies:
+      inherits: 2.0.4
+      safe-buffer: 5.2.1
     dev: true
 
   /shebang-command/1.2.0:
@@ -10338,10 +12102,6 @@ packages:
 
   /shellwords/0.1.1:
     resolution: {integrity: sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==}
-    dev: true
-
-  /sigmund/1.0.1:
-    resolution: {integrity: sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=}
     dev: true
 
   /signal-exit/3.0.3:
@@ -10508,6 +12268,10 @@ packages:
       sort-object-keys: 1.1.3
     dev: true
 
+  /source-list-map/2.0.1:
+    resolution: {integrity: sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==}
+    dev: true
+
   /source-map-resolve/0.5.2:
     resolution: {integrity: sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==}
     deprecated: See https://github.com/lydell/source-map-resolve#deprecated
@@ -10525,8 +12289,8 @@ packages:
       source-map: 0.5.7
     dev: true
 
-  /source-map-support/0.5.9:
-    resolution: {integrity: sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==}
+  /source-map-support/0.5.21:
+    resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
     dependencies:
       buffer-from: 1.1.1
       source-map: 0.6.1
@@ -10600,6 +12364,12 @@ packages:
     resolution: {integrity: sha1-Nr54Mgr+WAH2zqPueLblqrlA6gw=}
     dev: true
 
+  /ssri/6.0.2:
+    resolution: {integrity: sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==}
+    dependencies:
+      figgy-pudding: 3.5.2
+    dev: true
+
   /ssri/7.1.1:
     resolution: {integrity: sha512-w+daCzXN89PseTL99MkA+fxJEcU3wfaE/ah0i0lnOlpG1CYLJ2ZjzEry68YBKfLs4JfoTShrTEsJkAZuNZ/stw==}
     engines: {node: '>= 8'}
@@ -10640,6 +12410,34 @@ packages:
   /statuses/1.5.0:
     resolution: {integrity: sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=}
     engines: {node: '>= 0.6'}
+    dev: true
+
+  /stream-browserify/2.0.2:
+    resolution: {integrity: sha512-nX6hmklHs/gr2FuxYDltq8fJA1GDlxKQCz8O/IM4atRqBH8OORmBNgfvW5gG10GT/qQ9u0CzIvr2X5Pkt6ntqg==}
+    dependencies:
+      inherits: 2.0.4
+      readable-stream: 2.3.6
+    dev: true
+
+  /stream-each/1.2.3:
+    resolution: {integrity: sha512-vlMC2f8I2u/bZGqkdfLQW/13Zihpej/7PmSiMQsbYddxuTsJp8vRe2x2FvVExZg7FaOds43ROAuFJwPR4MTZLw==}
+    dependencies:
+      end-of-stream: 1.4.1
+      stream-shift: 1.0.1
+    dev: true
+
+  /stream-http/2.8.3:
+    resolution: {integrity: sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==}
+    dependencies:
+      builtin-status-codes: 3.0.0
+      inherits: 2.0.4
+      readable-stream: 2.3.6
+      to-arraybuffer: 1.0.1
+      xtend: 4.0.1
+    dev: true
+
+  /stream-shift/1.0.1:
+    resolution: {integrity: sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==}
     dev: true
 
   /string-length/4.0.1:
@@ -10768,12 +12566,6 @@ packages:
       chalk: 1.1.3
     dev: true
 
-  /supports-color/1.2.0:
-    resolution: {integrity: sha1-/x7R5hFp0Gs88tWI4YixjYhH4X4=}
-    engines: {node: '>=0.10.0'}
-    hasBin: true
-    dev: true
-
   /supports-color/2.0.0:
     resolution: {integrity: sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=}
     engines: {node: '>=0.8.0'}
@@ -10867,6 +12659,11 @@ packages:
       minipass: 2.3.5
     dev: true
 
+  /tapable/1.1.3:
+    resolution: {integrity: sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==}
+    engines: {node: '>=6'}
+    dev: true
+
   /tar/6.1.11:
     resolution: {integrity: sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==}
     engines: {node: '>= 10'}
@@ -10893,6 +12690,34 @@ packages:
     dependencies:
       ansi-escapes: 4.3.0
       supports-hyperlinks: 2.1.0
+    dev: true
+
+  /terser-webpack-plugin/1.4.5_webpack@4.46.0:
+    resolution: {integrity: sha512-04Rfe496lN8EYruwi6oPQkG0vo8C+HT49X687FZnpPF0qMAIHONI6HEXYPKDOE8e5HjXTyKfqRd/agHtH0kOtw==}
+    engines: {node: '>= 6.9.0'}
+    peerDependencies:
+      webpack: ^4.0.0
+    dependencies:
+      cacache: 12.0.4
+      find-cache-dir: 2.1.0
+      is-wsl: 1.1.0
+      schema-utils: 1.0.0
+      serialize-javascript: 4.0.0
+      source-map: 0.6.1
+      terser: 4.8.0
+      webpack: 4.46.0
+      webpack-sources: 1.4.3
+      worker-farm: 1.7.0
+    dev: true
+
+  /terser/4.8.0:
+    resolution: {integrity: sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+    dependencies:
+      commander: 2.20.3
+      source-map: 0.6.1
+      source-map-support: 0.5.21
     dev: true
 
   /test-exclude/6.0.0:
@@ -10973,10 +12798,31 @@ packages:
     resolution: {integrity: sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=}
     dev: true
 
+  /through2/2.0.5:
+    resolution: {integrity: sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==}
+    dependencies:
+      readable-stream: 2.3.6
+      xtend: 4.0.1
+    dev: true
+
   /through2/3.0.1:
     resolution: {integrity: sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==}
     dependencies:
       readable-stream: 3.3.0
+    dev: true
+
+  /timers-browserify/2.0.12:
+    resolution: {integrity: sha512-9phl76Cqm6FhSX9Xe1ZUAMLtm1BLkKj2Qd5ApyWkXzsMRaA7dgr81kf4wJmQf/hAvg8EEyJxDo3du/0KlhPiKQ==}
+    engines: {node: '>=0.6.0'}
+    dependencies:
+      setimmediate: 1.0.5
+    dev: true
+
+  /tiny-glob/0.2.9:
+    resolution: {integrity: sha512-g/55ssRPUjShh+xkfx9UPDXqhckHEsHr4Vd9zX55oSdGZc/MD0m3sferOkwWtp98bv+kcVfEHtRJgBVJzelrzg==}
+    dependencies:
+      globalyzer: 0.1.0
+      globrex: 0.1.2
     dev: true
 
   /tiny-lr/2.0.0:
@@ -11019,6 +12865,10 @@ packages:
     resolution: {integrity: sha1-F+bBH3PdTz10zaek/zI46a2b+JA=}
     dev: true
 
+  /to-arraybuffer/1.0.1:
+    resolution: {integrity: sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=}
+    dev: true
+
   /to-fast-properties/1.0.3:
     resolution: {integrity: sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=}
     engines: {node: '>=0.10.0'}
@@ -11027,11 +12877,6 @@ packages:
   /to-fast-properties/2.0.0:
     resolution: {integrity: sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=}
     engines: {node: '>=4'}
-    dev: true
-
-  /to-iso-string/0.0.2:
-    resolution: {integrity: sha1-TcGeZk38y+Jb2NtQiwDG2hWCVdE=}
-    deprecated: to-iso-string has been deprecated, use @segment/to-iso-string instead.
     dev: true
 
   /to-object-path/0.3.0:
@@ -11128,6 +12973,10 @@ packages:
     resolution: {integrity: sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==}
     dev: true
 
+  /tty-browserify/0.0.0:
+    resolution: {integrity: sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=}
+    dev: true
+
   /type-check/0.3.2:
     resolution: {integrity: sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=}
     engines: {node: '>= 0.8.0'}
@@ -11173,6 +13022,14 @@ packages:
     resolution: {integrity: sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==}
     dependencies:
       is-typedarray: 1.0.0
+    dev: true
+
+  /typedarray/0.0.6:
+    resolution: {integrity: sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=}
+    dev: true
+
+  /typescript-memoize/1.1.0:
+    resolution: {integrity: sha512-LQPKVXK8QrBBkL/zclE6YgSWn0I8ew5m0Lf+XL00IwMhlotqRLlzHV+BRrljVQIc+NohUAuQP7mg4HQwrx5Xbg==}
     dev: true
 
   /uc.micro/1.0.5:
@@ -11250,6 +13107,10 @@ packages:
       crypto-random-string: 2.0.0
     dev: true
 
+  /universalify/0.1.1:
+    resolution: {integrity: sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc=}
+    dev: true
+
   /universalify/0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
@@ -11285,6 +13146,12 @@ packages:
       os-homedir: 1.0.2
     dev: true
 
+  /upath/1.2.0:
+    resolution: {integrity: sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==}
+    engines: {node: '>=4'}
+    dev: true
+    optional: true
+
   /uri-js/4.2.2:
     resolution: {integrity: sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==}
     dependencies:
@@ -11303,6 +13170,13 @@ packages:
       prepend-http: 2.0.0
     dev: true
 
+  /url/0.11.0:
+    resolution: {integrity: sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=}
+    dependencies:
+      punycode: 1.3.2
+      querystring: 0.2.0
+    dev: true
+
   /use/3.1.1:
     resolution: {integrity: sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==}
     engines: {node: '>=0.10.0'}
@@ -11318,6 +13192,18 @@ packages:
 
   /util-deprecate/1.0.2:
     resolution: {integrity: sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=}
+    dev: true
+
+  /util/0.10.3:
+    resolution: {integrity: sha1-evsa/lCAUkZInj23/g7TeTNqwPk=}
+    dependencies:
+      inherits: 2.0.1
+    dev: true
+
+  /util/0.11.1:
+    resolution: {integrity: sha512-HShAsny+zS2TZfaXxD9tYj4HQGlBezXZMZuM/S5PKLLoZkShZiGk9o5CzukI1LVHZvjdvZ2Sj1aW/Ndn2NB/HQ==}
+    dependencies:
+      inherits: 2.0.3
     dev: true
 
   /utils-merge/1.0.1:
@@ -11349,6 +13235,13 @@ packages:
       builtins: 1.0.3
     dev: true
 
+  /validate-peer-dependencies/1.2.0:
+    resolution: {integrity: sha512-nd2HUpKc6RWblPZQ2GDuI65sxJ2n/UqZwSBVtj64xlWjMx0m7ZB2m9b2JS3v1f+n9VWH/dd1CMhkHfP6pIdckA==}
+    dependencies:
+      resolve-package-path: 3.1.0
+      semver: 7.3.4
+    dev: true
+
   /vary/1.1.2:
     resolution: {integrity: sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=}
     engines: {node: '>= 0.8'}
@@ -11356,6 +13249,10 @@ packages:
 
   /vlq/0.2.3:
     resolution: {integrity: sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow==}
+    dev: true
+
+  /vm-browserify/1.1.2:
+    resolution: {integrity: sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==}
     dev: true
 
   /w3c-hr-time/1.0.2:
@@ -11412,6 +13309,24 @@ packages:
       tmp: 0.1.0
     dev: true
 
+  /watchpack-chokidar2/2.0.1:
+    resolution: {integrity: sha512-nCFfBIPKr5Sh61s4LPpy1Wtfi0HE8isJ3d2Yb5/Ppw2P2B/3eVSEBjKfN0fmHJSK14+31KwMKmcrzs2GM4P0Ww==}
+    requiresBuild: true
+    dependencies:
+      chokidar: 2.1.8
+    dev: true
+    optional: true
+
+  /watchpack/1.7.5:
+    resolution: {integrity: sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==}
+    dependencies:
+      graceful-fs: 4.2.9
+      neo-async: 2.6.2
+    optionalDependencies:
+      chokidar: 3.5.3
+      watchpack-chokidar2: 2.0.1
+    dev: true
+
   /wcwidth/1.0.1:
     resolution: {integrity: sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=}
     dependencies:
@@ -11430,6 +13345,51 @@ packages:
   /webidl-conversions/6.1.0:
     resolution: {integrity: sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==}
     engines: {node: '>=10.4'}
+    dev: true
+
+  /webpack-sources/1.4.3:
+    resolution: {integrity: sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==}
+    dependencies:
+      source-list-map: 2.0.1
+      source-map: 0.6.1
+    dev: true
+
+  /webpack/4.46.0:
+    resolution: {integrity: sha512-6jJuJjg8znb/xRItk7bkT0+Q7AHCYjjFnvKIWQPkNIOyRqoCGvkOs0ipeQzrqz4l5FtN5ZI/ukEHroeX/o1/5Q==}
+    engines: {node: '>=6.11.5'}
+    hasBin: true
+    peerDependencies:
+      webpack-cli: '*'
+      webpack-command: '*'
+    peerDependenciesMeta:
+      webpack-cli:
+        optional: true
+      webpack-command:
+        optional: true
+    dependencies:
+      '@webassemblyjs/ast': 1.9.0
+      '@webassemblyjs/helper-module-context': 1.9.0
+      '@webassemblyjs/wasm-edit': 1.9.0
+      '@webassemblyjs/wasm-parser': 1.9.0
+      acorn: 6.4.2
+      ajv: 6.12.4
+      ajv-keywords: 3.5.2_ajv@6.12.4
+      chrome-trace-event: 1.0.3
+      enhanced-resolve: 4.5.0
+      eslint-scope: 4.0.3
+      json-parse-better-errors: 1.0.2
+      loader-runner: 2.4.0
+      loader-utils: 1.4.0
+      memory-fs: 0.4.1
+      micromatch: 3.1.10
+      mkdirp: 0.5.5
+      neo-async: 2.6.2
+      node-libs-browser: 2.2.1
+      schema-utils: 1.0.0
+      tapable: 1.1.3
+      terser-webpack-plugin: 1.4.5_webpack@4.46.0
+      watchpack: 1.7.5
+      webpack-sources: 1.4.3
     dev: true
 
   /websocket-driver/0.7.0:
@@ -11510,10 +13470,10 @@ packages:
     resolution: {integrity: sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=}
     dev: true
 
-  /workerpool/2.3.0:
-    resolution: {integrity: sha512-JP5DpviEV84zDmz13QnD4FfRjZBjnTOYY2O4pGgxtlqLh47WOzQFHm8o17TE5OSfcDoKC6vHSrN4yPju93DW0Q==}
+  /worker-farm/1.7.0:
+    resolution: {integrity: sha512-rvw3QTZc8lAxyVrqcSGVm5yP/IJ2UcB3U0graE3LCFoZ0Yn2x4EoVSqJKdB/T5M+FLcRPjz4TDacRf3OCfNUzw==}
     dependencies:
-      object-assign: 4.1.1
+      errno: 0.1.8
     dev: true
 
   /workerpool/3.1.2:

--- a/tests/.eslintrc.js
+++ b/tests/.eslintrc.js
@@ -1,7 +1,7 @@
 /* eslint-env node */
 
 module.exports = {
-  extends: 'simplabs/configs/ember-mocha',
+  extends: 'simplabs/configs/ember-qunit',
   parserOptions: {
     ecmaVersion: 2017
   },

--- a/tests/index.html
+++ b/tests/index.html
@@ -21,6 +21,13 @@
     {{content-for "body"}}
     {{content-for "test-body"}}
 
+    <div id="qunit"></div>
+    <div id="qunit-fixture">
+      <div id="ember-testing-container">
+        <div id="ember-testing"></div>
+      </div>
+    </div>
+
     <script src="/testem.js" integrity=""></script>
     <script src="{{rootURL}}assets/vendor.js"></script>
     <script src="{{rootURL}}assets/test-support.js"></script>

--- a/tests/minifier-test.js
+++ b/tests/minifier-test.js
@@ -1,156 +1,155 @@
-import { expect } from 'chai';
-import { describe, it, beforeEach } from 'mocha';
-import { setupRenderingTest } from 'ember-mocha';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
-describe('HBS Minifier plugin', function() {
-  setupRenderingTest();
+module('HBS Minifier plugin', function(hooks) {
+  setupRenderingTest(hooks);
 
-  beforeEach(function() {
+  hooks.beforeEach(function() {
     this.setProperties({ foo: 'foo', bar: 'bar', baz: 'baz' });
   });
 
-  it('collapses whitespace into single space character', async function() {
+  test('collapses whitespace into single space character', async function(assert) {
     await render(hbs`{{foo}}  \n\n   \n{{bar}}`);
 
     let childNodes = [...this.element.childNodes].filter(it => it.textContent !== '');
-    expect(childNodes.length).to.equal(3);
-    expect(childNodes[1]).to.be.a('text');
-    expect(childNodes[1]).to.have.a.property('textContent', ' ');
+    assert.strictEqual(childNodes.length, 3);
+    assert.strictEqual(childNodes[1].nodeName, '#text');
+    assert.strictEqual(childNodes[1].textContent, ' ');
   });
 
-  it('strips leading and trailing whitespace from Program nodes', async function() {
+  test('strips leading and trailing whitespace from Program nodes', async function(assert) {
     await render(hbs`        {{foo}}        `);
 
     let childNodes = [...this.element.childNodes].filter(it => it.textContent !== '');
-    expect(childNodes.length).to.equal(1);
-    expect(childNodes[0]).to.be.a('text');
-    expect(childNodes[0]).to.have.a.property('textContent', 'foo');
+    assert.strictEqual(childNodes.length, 1);
+    assert.strictEqual(childNodes[0].nodeName, '#text');
+    assert.strictEqual(childNodes[0].textContent, 'foo');
   });
 
-  it('Collapse leading/trailing text from Program nodes into a single whitespace', async function() {
+  test('Collapse leading/trailing text from Program nodes into a single whitespace', async function(assert) {
     await render(hbs`x        {{foo}}     y   `);
 
     let childNodes = [...this.element.childNodes].filter(it => it.textContent !== '');
-    expect(childNodes.length).to.equal(3);
-    expect(childNodes[0]).to.be.a('text');
-    expect(childNodes[0]).to.have.a.property('textContent', 'x ');
-    expect(childNodes[1]).to.be.a('text');
-    expect(childNodes[1]).to.have.a.property('textContent', 'foo');
-    expect(childNodes[2]).to.be.a('text');
-    expect(childNodes[2]).to.have.a.property('textContent', ' y ');
+    assert.strictEqual(childNodes.length, 3);
+    assert.strictEqual(childNodes[0].nodeName, '#text');
+    assert.strictEqual(childNodes[0].textContent, 'x ');
+    assert.strictEqual(childNodes[1].nodeName, '#text');
+    assert.strictEqual(childNodes[1].textContent, 'foo');
+    assert.strictEqual(childNodes[2].nodeName, '#text');
+    assert.strictEqual(childNodes[2].textContent, ' y ');
   });
 
-  it('strips leading and trailing whitespace from ElementNode nodes', async function() {
+  test('strips leading and trailing whitespace from ElementNode nodes', async function(assert) {
     await render(hbs`<div>        {{foo}}        </div>`);
 
     let childNodes = this.element.querySelector('div').childNodes;
-    expect(childNodes.length).to.equal(1);
-    expect(childNodes[0]).to.be.a('text');
-    expect(childNodes[0]).to.have.a.property('textContent', 'foo');
+    assert.strictEqual(childNodes.length, 1);
+    assert.strictEqual(childNodes[0].nodeName, '#text');
+    assert.strictEqual(childNodes[0].textContent, 'foo');
   });
 
-  it('Collapse leading/trailing text from ElementNode nodes', async function() {
+  test('Collapse leading/trailing text from ElementNode nodes', async function(assert) {
     await render(hbs`<div>x        {{foo}}     y   {{bar}}    z</div>`);
 
     let childNodes = this.element.querySelector('div').childNodes;
-    expect(childNodes.length).to.equal(5);
-    expect(childNodes[0]).to.be.a('text');
-    expect(childNodes[0]).to.have.a.property('textContent', 'x ');
-    expect(childNodes[1]).to.be.a('text');
-    expect(childNodes[1]).to.have.a.property('textContent', 'foo');
-    expect(childNodes[2]).to.be.a('text');
-    expect(childNodes[2]).to.have.a.property('textContent', ' y ');
-    expect(childNodes[3]).to.have.a.property('textContent', 'bar');
-    expect(childNodes[4]).to.have.a.property('textContent', ' z');
+    assert.strictEqual(childNodes.length, 5);
+    assert.strictEqual(childNodes[0].nodeName, '#text');
+    assert.strictEqual(childNodes[0].textContent, 'x ');
+    assert.strictEqual(childNodes[1].nodeName, '#text');
+    assert.strictEqual(childNodes[1].textContent, 'foo');
+    assert.strictEqual(childNodes[2].nodeName, '#text');
+    assert.strictEqual(childNodes[2].textContent, ' y ');
+    assert.strictEqual(childNodes[3].textContent, 'bar');
+    assert.strictEqual(childNodes[4].textContent, ' z');
   });
 
-  it('does not strip inside of <pre> tags', async function() {
+  test('does not strip inside of <pre> tags', async function(assert) {
     await render(hbs`<pre>        {{foo}}        </pre>`);
 
     let childNodes = this.element.querySelector('pre').childNodes;
-    expect(childNodes.length).to.equal(3);
-    expect(childNodes[0]).to.be.a('text');
-    expect(childNodes[0]).to.have.a.property('textContent', '        ');
-    expect(childNodes[1]).to.be.a('text');
-    expect(childNodes[1]).to.have.a.property('textContent', 'foo');
-    expect(childNodes[2]).to.be.a('text');
-    expect(childNodes[2]).to.have.a.property('textContent', '        ');
+    assert.strictEqual(childNodes.length, 3);
+    assert.strictEqual(childNodes[0].nodeName, '#text');
+    assert.strictEqual(childNodes[0].textContent, '        ');
+    assert.strictEqual(childNodes[1].nodeName, '#text');
+    assert.strictEqual(childNodes[1].textContent, 'foo');
+    assert.strictEqual(childNodes[2].nodeName, '#text');
+    assert.strictEqual(childNodes[2].textContent, '        ');
   });
 
-  it('does not collapse whitespace inside of <pre> tags', async function() {
+  test('does not collapse whitespace inside of <pre> tags', async function(assert) {
     await render(hbs`<pre>  \n\n   \n</pre>`);
 
     let childNodes = this.element.querySelector('pre').childNodes;
-    expect(childNodes.length).to.equal(1);
-    expect(childNodes[0]).to.be.a('text');
-    expect(childNodes[0]).to.have.a.property('textContent', '  \n\n   \n');
+    assert.strictEqual(childNodes.length, 1);
+    assert.strictEqual(childNodes[0].nodeName, '#text');
+    assert.strictEqual(childNodes[0].textContent, '  \n\n   \n');
   });
 
-  it('does not strip inside of {{#no-minify}} tags', async function() {
+  test('does not strip inside of {{#no-minify}} tags', async function(assert) {
     await render(hbs`{{#no-minify}}        {{foo}}        {{/no-minify}}`);
 
     let childNodes = [...this.element.childNodes].filter(it => it.textContent !== '');
-    expect(childNodes.length).to.equal(3);
-    expect(childNodes[0]).to.be.a('text');
-    expect(childNodes[0]).to.have.a.property('textContent', '        ');
-    expect(childNodes[1]).to.be.a('text');
-    expect(childNodes[1]).to.have.a.property('textContent', 'foo');
-    expect(childNodes[2]).to.be.a('text');
-    expect(childNodes[2]).to.have.a.property('textContent', '        ');
+    assert.strictEqual(childNodes.length, 3);
+    assert.strictEqual(childNodes[0].nodeName, '#text');
+    assert.strictEqual(childNodes[0].textContent, '        ');
+    assert.strictEqual(childNodes[1].nodeName, '#text');
+    assert.strictEqual(childNodes[1].textContent, 'foo');
+    assert.strictEqual(childNodes[2].nodeName, '#text');
+    assert.strictEqual(childNodes[2].textContent, '        ');
   });
 
-  it('does not strip inside of {{#no-minify}} tags in other tags', async function() {
+  test('does not strip inside of {{#no-minify}} tags in other tags', async function(assert) {
     await render(hbs`<div>{{#no-minify}}        {{foo}}        {{/no-minify}}</div>`);
 
     let childNodes = this.element.querySelector('div').childNodes;
-    expect(childNodes.length).to.equal(3);
-    expect(childNodes[0]).to.be.a('text');
-    expect(childNodes[0]).to.have.a.property('textContent', '        ');
-    expect(childNodes[1]).to.be.a('text');
-    expect(childNodes[1]).to.have.a.property('textContent', 'foo');
-    expect(childNodes[2]).to.be.a('text');
-    expect(childNodes[2]).to.have.a.property('textContent', '        ');
+    assert.strictEqual(childNodes.length, 3);
+    assert.strictEqual(childNodes[0].nodeName, '#text');
+    assert.strictEqual(childNodes[0].textContent, '        ');
+    assert.strictEqual(childNodes[1].nodeName, '#text');
+    assert.strictEqual(childNodes[1].textContent, 'foo');
+    assert.strictEqual(childNodes[2].nodeName, '#text');
+    assert.strictEqual(childNodes[2].textContent, '        ');
   });
 
-  it('does not collapse whitespace inside of {{#no-minify}} tags in other tags', async function() {
+  test('does not collapse whitespace inside of {{#no-minify}} tags in other tags', async function(assert) {
     await render(hbs`<div>{{#no-minify}}  \n\n   \n{{/no-minify}}</div>`);
 
     let childNodes = this.element.querySelector('div').childNodes;
-    expect(childNodes.length).to.equal(1);
-    expect(childNodes[0]).to.be.a('text');
-    expect(childNodes[0]).to.have.a.property('textContent', '  \n\n   \n');
+    assert.strictEqual(childNodes.length, 1);
+    assert.strictEqual(childNodes[0].nodeName, '#text');
+    assert.strictEqual(childNodes[0].textContent, '  \n\n   \n');
   });
 
-  it('does not collapse multiple &nbsp; textNode into a single whitespace', async function() {
+  test('does not collapse multiple &nbsp; textNode into a single whitespace', async function(assert) {
     await render(hbs`<span>1</span>&nbsp;&nbsp;<span>2</span>`);
     let childNodes = [...this.element.childNodes].filter(it => it.textContent !== '');
-    expect(childNodes.length).to.equal(3);
-    expect(childNodes[1]).to.be.a('text');
+    assert.strictEqual(childNodes.length, 3);
+    assert.strictEqual(childNodes[1].nodeName, '#text');
     // checking for the length of the textNode is 2.
-    expect(childNodes[1].nodeValue.length).to.equal(2);
+    assert.strictEqual(childNodes[1].nodeValue.length, 2);
     // ensuring the textNode contains only whitespaces
-    expect(childNodes[1].nodeValue.trim()).to.equal('');
+    assert.strictEqual(childNodes[1].nodeValue.trim(), '');
   });
   /*
     The following test is so much similar to the above one. But we need to make sure that the textNode in following templates results in
     '  1  ' and not ' 1 '.
   */
-  it('does not collapse &nbsp; surrounding a text content into a single whitespace', async function() {
+  test('does not collapse &nbsp; surrounding a text content into a single whitespace', async function(assert) {
     await render(hbs `
 <div>
   <span>    &nbsp;1&nbsp;   </span>
   <span> 2   </span>
 </div>`);
     let childNode = this.element.querySelectorAll('div span')[0].childNodes[0];
-    expect(childNode.textContent.length).to.equal(5);
-    expect(childNode).to.be.a('text');
+    assert.strictEqual(childNode.textContent.length, 5);
+    assert.strictEqual(childNode.nodeName, '#text');
     // ensuring the textContent is surrounded by whitespaces
-    expect(childNode.textContent.trim()).to.equal('1');
+    assert.strictEqual(childNode.textContent.trim(), '1');
   });
 
-  it('does not minify `tagNames` specified in .hbs-minifyrc.js', async function() {
+  test('does not minify `tagNames` specified in .hbs-minifyrc.js', async function(assert) {
     await render(hbs `
 <address>
   Box 564,
@@ -162,16 +161,16 @@ describe('HBS Minifier plugin', function() {
 </address>`);
 
     let childNodes = this.element.querySelector('address').childNodes;
-    expect(childNodes[0].textContent).to.equal('\n  Box 564,\n  ');
+    assert.strictEqual(childNodes[0].textContent, '\n  Box 564,\n  ');
     // ensuring the textContent is surrounded by whitespaces
-    expect(childNodes[1].textContent).to.equal('\n    Disneyland\n  ');
-    expect(childNodes[2].textContent).to.equal('\n  ');
-    expect(childNodes[4].textContent).to.equal('\n  ');
-    expect(childNodes[5].textContent).to.equal(' USA ');
+    assert.strictEqual(childNodes[1].textContent, '\n    Disneyland\n  ');
+    assert.strictEqual(childNodes[2].textContent, '\n  ');
+    assert.strictEqual(childNodes[4].textContent, '\n  ');
+    assert.strictEqual(childNodes[5].textContent, ' USA ');
   });
 
 
-  it('does not minify `classNames` specified in .hbs-minifyrc.js', async function() {
+  test('does not minify `classNames` specified in .hbs-minifyrc.js', async function(assert) {
     await render(hbs `
 <div class="description">
   1
@@ -181,12 +180,12 @@ describe('HBS Minifier plugin', function() {
 </div>`);
 
     let childNodes = this.element.querySelector('div').childNodes;
-    expect(childNodes[0].textContent).to.equal('\n  1\n  ');
-    expect(childNodes[1].textContent).to.equal('\n    2\n  ');
-    expect(childNodes[2].textContent).to.equal('\n');
+    assert.strictEqual(childNodes[0].textContent, '\n  1\n  ');
+    assert.strictEqual(childNodes[1].textContent, '\n    2\n  ');
+    assert.strictEqual(childNodes[2].textContent, '\n');
   });
 
-  it('does not minify `component` boundaries specified in .hbs-minifyrc.js', async function() {
+  test('does not minify `component` boundaries specified in .hbs-minifyrc.js', async function(assert) {
     await render(hbs `
 {{#foo-bar}}
   <span>
@@ -195,16 +194,16 @@ describe('HBS Minifier plugin', function() {
 {{/foo-bar}}`);
 
     let childNodes = this.element.querySelector('div').childNodes;
-    expect(childNodes[0].textContent).to.equal('1 ');
-    expect(childNodes[1].textContent).to.equal(' 2 ');
-    expect(childNodes[3].textContent).to.equal(' 3 ');
-    expect(childNodes[4].textContent).to.equal(' ');
-    expect(childNodes[5].textContent).to.equal('  ');
-    expect(childNodes[6].textContent).to.equal('\n    yield content\n  ');
-    expect(childNodes[7].textContent).to.equal('\n');
+    assert.strictEqual(childNodes[0].textContent, '1 ');
+    assert.strictEqual(childNodes[1].textContent, ' 2 ');
+    assert.strictEqual(childNodes[3].textContent, ' 3 ');
+    assert.strictEqual(childNodes[4].textContent, ' ');
+    assert.strictEqual(childNodes[5].textContent, '  ');
+    assert.strictEqual(childNodes[6].textContent, '\n    yield content\n  ');
+    assert.strictEqual(childNodes[7].textContent, '\n');
   });
 
-  it('minify `tagNames` that are not specified in .hbs-minifyrc.js', async function() {
+  test('minify `tagNames` that are not specified in .hbs-minifyrc.js', async function(assert) {
     await render(hbs `
   <ul>
     <li>
@@ -216,13 +215,13 @@ describe('HBS Minifier plugin', function() {
   </ul>`);
 
     let childNodes = this.element.querySelector('ul').childNodes;
-    expect(childNodes.length).to.equal(3);
-    expect(childNodes[0].textContent).to.equal(' 1 ');
-    expect(childNodes[1].textContent).to.equal(' ');
-    expect(childNodes[2].textContent).to.equal(' 2 ');
+    assert.strictEqual(childNodes.length, 3);
+    assert.strictEqual(childNodes[0].textContent, ' 1 ');
+    assert.strictEqual(childNodes[1].textContent, ' ');
+    assert.strictEqual(childNodes[2].textContent, ' 2 ');
   });
 
-  it('minifies `classNames` that are not specified in .hbs-minifyrc.js', async function() {
+  test('minifies `classNames` that are not specified in .hbs-minifyrc.js', async function(assert) {
     await render(hbs `
 <div class="numbers">
   1
@@ -232,12 +231,12 @@ describe('HBS Minifier plugin', function() {
 </div>`);
 
     let childNodes = this.element.querySelector('div').childNodes;
-    expect(childNodes.length).to.equal(2);
-    expect(childNodes[0].textContent).to.equal(' 1 ');
-    expect(childNodes[1].textContent).to.equal(' 2 ');
+    assert.strictEqual(childNodes.length, 2);
+    assert.strictEqual(childNodes[0].textContent, ' 1 ');
+    assert.strictEqual(childNodes[1].textContent, ' 2 ');
   });
 
-  it('minify `component` boundaries that are not specified in .hbs-minifyrc.js', async function() {
+  test('minify `component` boundaries that are not specified in .hbs-minifyrc.js', async function(assert) {
     await render(hbs `
 {{#x-button tagName="button"}}
   <div>
@@ -247,12 +246,12 @@ describe('HBS Minifier plugin', function() {
 
     let childNodes = this.element.querySelector('button').childNodes;
     // removing the textNodes with content as '' since htmlbars adds text node boundaries (at the begining and the end) of a template file.
-    expect([...childNodes].filter(node => node.textContent !== '').length).to.equal(2);
-    expect(childNodes[0].textContent).to.equal('save ');
-    expect(childNodes[1].nodeName).to.equal('DIV');
+    assert.strictEqual([...childNodes].filter(node => node.textContent !== '').length, 2);
+    assert.strictEqual(childNodes[0].textContent, 'save ');
+    assert.strictEqual(childNodes[1].nodeName, 'DIV');
     let yieldElementChildNodes = this.element.querySelector('div').childNodes;
-    expect(yieldElementChildNodes.length).to.equal(1);
-    expect(yieldElementChildNodes[0].textContent).to.equal(' yield content ');
+    assert.strictEqual(yieldElementChildNodes.length, 1);
+    assert.strictEqual(yieldElementChildNodes[0].textContent, ' yield content ');
   });
 
 

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -1,7 +1,7 @@
 import Application from '../app';
 import config from '../config/environment';
 import { setApplication } from '@ember/test-helpers';
-import { start } from 'ember-mocha';
+import { start } from 'ember-qunit';
 
 setApplication(Application.create(config.APP));
 


### PR DESCRIPTION
`ember-mocha` isn't well maintained anymore unfortunately, so we will move to QUnit to unblock a few dependency updates and fix deprecation warnings.