### PR TITLE
Remove unused `ember-cli-htmlbars-inline-precompile` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "ember-cli-chai": "0.5.0",
     "ember-cli-dependency-checker": "3.2.0",
     "ember-cli-htmlbars": "6.0.1",
-    "ember-cli-htmlbars-inline-precompile": "3.0.2",
     "ember-cli-inject-live-reload": "2.1.0",
     "ember-disable-prototype-extensions": "1.1.3",
     "ember-load-initializers": "2.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,6 @@ specifiers:
   ember-cli-chai: 0.5.0
   ember-cli-dependency-checker: 3.2.0
   ember-cli-htmlbars: 6.0.1
-  ember-cli-htmlbars-inline-precompile: 3.0.2
   ember-cli-inject-live-reload: 2.1.0
   ember-disable-prototype-extensions: 1.1.3
   ember-load-initializers: 2.1.2
@@ -44,7 +43,6 @@ devDependencies:
   ember-cli-chai: 0.5.0
   ember-cli-dependency-checker: 3.2.0
   ember-cli-htmlbars: 6.0.1
-  ember-cli-htmlbars-inline-precompile: 3.0.2_ember-cli-babel@7.26.11
   ember-cli-inject-live-reload: 2.1.0
   ember-disable-prototype-extensions: 1.1.3
   ember-load-initializers: 2.1.2
@@ -2838,11 +2836,6 @@ packages:
       lodash: 4.17.21
     dev: true
 
-  /babel-plugin-htmlbars-inline-precompile/2.1.1:
-    resolution: {integrity: sha512-obo5//IFrEZNAQovcXxOXLn5nwkQ0Y+xhR7AMg1sYR6W7KxQLZI9/XzbIytVhjwwY+Bd2e0+qyHEplJbHyZ1Og==}
-    engines: {node: 8.* || 10.* || >= 12.*}
-    dev: true
-
   /babel-plugin-htmlbars-inline-precompile/5.3.1:
     resolution: {integrity: sha512-QWjjFgSKtSRIcsBhJmEwS2laIdrA6na8HAlc/pEAhjHgQsah/gMiBFRZvbQTy//hWxR4BMwV7/Mya7q5H8uHeA==}
     engines: {node: 10.* || >= 12.*}
@@ -5094,22 +5087,6 @@ packages:
 
   /ember-cli-get-component-path-option/1.0.0:
     resolution: {integrity: sha1-DXtZVVni+QUKvtgE8djv8bCLx3E=}
-    dev: true
-
-  /ember-cli-htmlbars-inline-precompile/3.0.2_ember-cli-babel@7.26.11:
-    resolution: {integrity: sha512-A2N8HYytnzjCqBRw9jUX2WFGbECcZiwrcDE9lkfCQG0JLhCFnleRXFFPp4Wlqu08zqxfxKPDvLgseKYjlLmHFQ==}
-    engines: {node: 8.* || 10.* || >= 12.*}
-    deprecated: Use ember-cli-htmlbars instead.
-    peerDependencies:
-      ember-cli-babel: ^7.0.0
-    dependencies:
-      babel-plugin-htmlbars-inline-precompile: 2.1.1
-      ember-cli-babel: 7.26.11
-      ember-cli-version-checker: 3.1.3
-      hash-for-dep: 1.5.1
-      heimdalljs-logger: 0.1.10
-      semver: 6.3.0
-      silent-error: 1.1.1
     dev: true
 
   /ember-cli-htmlbars/5.7.2:


### PR DESCRIPTION
This is no longer needed with the current version of ember-cli-htmlbars