### PR TITLE
Enable Ember Octane features

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,9 @@
   "engines": {
     "node": "10.* || >= 12.*"
   },
+  "ember": {
+    "edition": "octane"
+  },
   "ember-addon": {
     "configPath": "tests/dummy/config",
     "versionCompatibility": {

--- a/tests/dummy/config/optional-features.json
+++ b/tests/dummy/config/optional-features.json
@@ -1,5 +1,6 @@
 {
   "application-template-wrapper": false,
+  "default-async-observers": true,
   "jquery-integration": false,
   "template-only-glimmer-components": true
 }

--- a/tests/dummy/config/optional-features.json
+++ b/tests/dummy/config/optional-features.json
@@ -1,3 +1,4 @@
 {
-  "jquery-integration": false
+  "jquery-integration": false,
+  "template-only-glimmer-components": true
 }

--- a/tests/dummy/config/optional-features.json
+++ b/tests/dummy/config/optional-features.json
@@ -1,4 +1,5 @@
 {
+  "application-template-wrapper": false,
   "jquery-integration": false,
   "template-only-glimmer-components": true
 }


### PR DESCRIPTION
This is required in the dummy app to support Ember v4.